### PR TITLE
✨ feat(docker): F29 — Adminer e CloudBeaver (Database Viewer)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,11 @@ SQLITE_DB_PATH=
 
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
+
+# Adminer – Lightweight DB web UI (F29.01)
+# Access: http://localhost:8082
+ADMINER_PORT=8082
+
+# CloudBeaver – Full-featured database web IDE (F29.02)
+# Access: http://localhost:8083
+CLOUDBEAVER_PORT=8083

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build wiremock mockoon record record-stop convert-to-mockoon convert-to-wiremock clean help
+.PHONY: build wiremock mockoon record record-stop convert-to-mockoon convert-to-wiremock clean help \
+        adminer adminer-up adminer-down cloudbeaver cloudbeaver-up cloudbeaver-down db-viewer db-viewer-down
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -78,11 +79,39 @@ mysql-down: ## Stop MySQL services
 mysql-shell: ## Open mysql shell
 	docker compose exec db-mysql mysql -u $${MYSQL_USER:-stubrix} -p$${MYSQL_PASSWORD:-stubrix}
 
+# ---------------------------------------------------------------------------
+# Database Viewers (F29)
+# ---------------------------------------------------------------------------
+
+adminer: ## Start Adminer + PostgreSQL (lightweight DB web UI — http://localhost:8082)
+	docker compose --profile postgres --profile adminer up
+
+adminer-up: ## Start Adminer + PostgreSQL (detached)
+	docker compose --profile postgres --profile adminer up -d
+
+adminer-down: ## Stop Adminer
+	docker compose --profile adminer down
+
+cloudbeaver: ## Start CloudBeaver + PostgreSQL (full DB IDE — http://localhost:8083)
+	docker compose --profile postgres --profile cloudbeaver up
+
+cloudbeaver-up: ## Start CloudBeaver + PostgreSQL (detached)
+	docker compose --profile postgres --profile cloudbeaver up -d
+
+cloudbeaver-down: ## Stop CloudBeaver
+	docker compose --profile cloudbeaver down
+
+db-viewer: ## Start both Adminer + CloudBeaver + PostgreSQL (detached)
+	docker compose --profile postgres --profile db-viewer up -d
+
+db-viewer-down: ## Stop all DB viewers
+	docker compose --profile db-viewer down
+
 all-up: ## Start WireMock + PostgreSQL
 	docker compose --profile wiremock --profile postgres up -d
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -106,7 +135,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/config/cloudbeaver/cloudbeaver.conf
+++ b/config/cloudbeaver/cloudbeaver.conf
@@ -1,0 +1,27 @@
+{
+    "server": {
+        "serverPort": 8978,
+        "workspaceLocation": "workspace",
+        "contentRoot": "web",
+        "driversLocation": "drivers",
+        "rootURI": "/",
+        "serviceURI": "/api/",
+        "productConfiguration": "conf/product.conf",
+        "expireSessionAfterPeriod": 1800000,
+        "develMode": false,
+        "enableSecurityManager": false,
+        "database": {
+            "driver": "h2_embedded",
+            "url": "jdbc:h2:/opt/cloudbeaver/workspace/.data/cloudbeaver",
+            "createDatabase": true
+        }
+    },
+    "app": {
+        "anonymousAccessEnabled": true,
+        "anonymousUserRole": "user",
+        "grantConnectionsAccessToAnonymousTeam": true,
+        "supportsCustomConnections": true,
+        "showReadOnlyConnectionInfo": false,
+        "notificationsEnabled": true
+    }
+}

--- a/config/cloudbeaver/initial-data.conf
+++ b/config/cloudbeaver/initial-data.conf
@@ -1,0 +1,32 @@
+{
+    "connections": [
+        {
+            "id": "stubrix-postgres",
+            "name": "Stubrix PostgreSQL",
+            "description": "Stubrix PostgreSQL database (managed by Stubrix API)",
+            "provider": "postgresql",
+            "driver": "postgres-jdbc",
+            "url": "jdbc:postgresql://db-postgres:5432/${PG_DATABASE:-postgres}",
+            "authModel": "native",
+            "credentials": {
+                "user": "${PG_USER:-postgres}",
+                "password": "${PG_PASSWORD:-postgres}"
+            },
+            "savePassword": true
+        },
+        {
+            "id": "stubrix-mysql",
+            "name": "Stubrix MySQL",
+            "description": "Stubrix MySQL database (managed by Stubrix API)",
+            "provider": "mysql",
+            "driver": "mysql8",
+            "url": "jdbc:mysql://db-mysql:3306/${MYSQL_DATABASE:-stubrix}",
+            "authModel": "native",
+            "credentials": {
+                "user": "${MYSQL_USER:-stubrix}",
+                "password": "${MYSQL_PASSWORD:-stubrix}"
+            },
+            "savePassword": true
+        }
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,26 @@
 ## ==========================================================================
 ## Stubrix – Docker Compose (WireMock / Mockoon)
 ##
-## Usage:
-##   docker compose --profile databases up -d         # PostgreSQL only (SQLite runs on host)
+## Mock Engines:
 ##   docker compose --profile wiremock up -d          # run with WireMock
 ##   docker compose --profile mockoon  up -d          # run with Mockoon
 ##   docker compose --profile wiremock-record up -d   # WireMock in record mode
 ##   docker compose --profile mockoon-proxy  up -d    # Mockoon with proxy
+##
+## Databases:
 ##   docker compose --profile postgres up -d          # PostgreSQL only
 ##   docker compose --profile mysql up -d             # MySQL only
+##   docker compose --profile databases up -d         # PostgreSQL only (legacy alias)
+##
+## Database Viewers (F29):
+##   docker compose --profile adminer up -d           # Adminer UI  → http://localhost:8082
+##   docker compose --profile cloudbeaver up -d       # CloudBeaver → http://localhost:8083
+##   docker compose --profile db-viewer up -d         # Both viewers (Adminer + CloudBeaver)
+##
+## Shortcuts (see Makefile):
+##   make adminer-up      # PostgreSQL + Adminer
+##   make cloudbeaver-up  # PostgreSQL + CloudBeaver
+##   make db-viewer       # PostgreSQL + both viewers
 ## ==========================================================================
 
 x-common: &common
@@ -128,6 +140,43 @@ services:
   # SQLite runs directly on the host via the API, no Docker container needed.
   # Database files are stored in: ./dumps/sqlite/
 
+  # --------------------------------------------------------------------------
+  # Adminer – Lightweight database web UI (F29.01)
+  # Supports: PostgreSQL, MySQL, SQLite
+  # Access: http://localhost:8082
+  # --------------------------------------------------------------------------
+  adminer:
+    image: adminer:4
+    profiles: ["adminer", "db-viewer"]
+    container_name: stubrix-adminer
+    ports:
+      - "${ADMINER_PORT:-8082}:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: ${PG_HOST:-db-postgres}
+      ADMINER_DESIGN: pepa-linha-dark
+    depends_on:
+      db-postgres:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # CloudBeaver – Full-featured database web IDE (F29.02)
+  # Supports: PostgreSQL, MySQL, SQLite and 40+ databases
+  # Access: http://localhost:8083
+  # --------------------------------------------------------------------------
+  cloudbeaver:
+    image: dbeaver/cloudbeaver:latest
+    profiles: ["cloudbeaver", "db-viewer"]
+    container_name: stubrix-cloudbeaver
+    ports:
+      - "${CLOUDBEAVER_PORT:-8083}:8978"
+    volumes:
+      - cloudbeaver_data:/opt/cloudbeaver/workspace
+      - ./config/cloudbeaver:/opt/cloudbeaver/conf:ro
+    restart: unless-stopped
+
 volumes:
   pg_data:
   mysql_data:
+  cloudbeaver_data:


### PR DESCRIPTION
## 📝 Descrição

Implementação do épico **F29 — Adminer/CloudBeaver (Database Viewer)** no milestone **v1.4.0**.

Adiciona dois perfis Docker para visualização e gerenciamento de bancos de dados diretamente no ambiente Stubrix, sem necessidade de ferramentas locais instaladas.

## 🔗 Issues Relacionadas

Closes #190
Closes #191
Closes #192
Closes #193
Closes #51

## 🎯 O que foi implementado

### F29.01 — Adminer Docker Compose Profile (#190)
- Serviço `adminer` (imagem `adminer:4`) no profile `adminer`
- Porta configurável via `ADMINER_PORT` (padrão: 8082)
- Tema `pepa-linha-dark` por padrão
- `ADMINER_DEFAULT_SERVER` aponta para `db-postgres`

### F29.02 — CloudBeaver Docker Compose Profile (#191)
- Serviço `cloudbeaver` (imagem `dbeaver/cloudbeaver:latest`) no profile `cloudbeaver`
- Porta configurável via `CLOUDBEAVER_PORT` (padrão: 8083)
- Volume persistente `cloudbeaver_data`

### F29.03 — Pre-configured Database Connections (#192)
- `config/cloudbeaver/cloudbeaver.conf` — configuração do servidor (anonymous access, porta)
- `config/cloudbeaver/initial-data.conf` — conexões pré-configuradas para PostgreSQL e MySQL do Stubrix

### F29.04 — Documentation & Makefile Targets (#193)
- `make adminer` / `make adminer-up` / `make adminer-down`
- `make cloudbeaver` / `make cloudbeaver-up` / `make cloudbeaver-down`
- `make db-viewer` — sobe ambos os viewers + PostgreSQL
- `make db-viewer-down`
- Profile combinado `db-viewer` para subir Adminer + CloudBeaver juntos
- Header do `docker-compose.yml` atualizado com documentação dos novos profiles
- `all-down` e `clean` atualizados para incluir os novos profiles

## 🚀 Como usar

```bash
# Adminer (leve, ideal para uso rápido)
make adminer-up
# → http://localhost:8082

# CloudBeaver (IDE completo)
make cloudbeaver-up
# → http://localhost:8083

# Ambos juntos
make db-viewer
```

## 📊 Variáveis de ambiente

```env
ADMINER_PORT=8082
CLOUDBEAVER_PORT=8083
```