### PR TITLE
✨ feat(api): F9 + F11 — OpenRAG Intelligence Layer & Time Machine Scenarios (v1.7.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,13 @@ SQLITE_DB_PATH=
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
 
+# AI / RAG – OpenRAG + ChromaDB (F9.01)
+OPENRAG_URL=http://localhost:8888
+CHROMADB_PORT=8000
+OPENRAG_PORT=8888
+OPENAI_API_KEY=
+OLLAMA_HOST=
+
 # Hoppscotch – Self-Hosted API Client (F8.01)
 # Access: http://localhost:3100
 HOPPSCOTCH_PORT=3100

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build wiremock mockoon record record-stop convert-to-mockoon convert-to-wiremock clean help \
         adminer adminer-up adminer-down cloudbeaver cloudbeaver-up cloudbeaver-down db-viewer db-viewer-down \
         hoppscotch hoppscotch-down hoppscotch-logs \
-        bruno-test bruno-test-collection
+        bruno-test bruno-test-collection \
+        ai-up ai-down ai-logs \
+        scenario-save scenario-restore scenario-list
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -112,6 +114,28 @@ db-viewer-down: ## Stop all DB viewers
 all-up: ## Start WireMock + PostgreSQL
 	docker compose --profile wiremock --profile postgres up -d
 
+ai-up: ## Start ChromaDB + OpenRAG AI layer (F9.01 — detached)
+	docker compose --profile ai up -d
+
+ai-down: ## Stop AI/RAG services
+	docker compose --profile ai down
+
+ai-logs: ## Tail OpenRAG logs
+	docker compose --profile ai logs -f openrag
+
+scenario-save: ## Capture current state as a scenario (F11.06) — NAME=<name> required
+	@[ "$(NAME)" ] || (echo "ERROR: NAME is required. Usage: make scenario-save NAME=my-scenario" && exit 1)
+	curl -s -X POST http://localhost:9090/api/scenarios/capture \
+	  -H 'Content-Type: application/json' \
+	  -d '{"name":"$(NAME)"}' | jq .
+
+scenario-restore: ## Restore environment from a scenario (F11.06) — ID=<uuid> required
+	@[ "$(ID)" ] || (echo "ERROR: ID is required. Usage: make scenario-restore ID=<uuid>" && exit 1)
+	curl -s -X POST http://localhost:9090/api/scenarios/$(ID)/restore | jq .
+
+scenario-list: ## List all captured scenarios (F11.06)
+	curl -s http://localhost:9090/api/scenarios | jq .
+
 hoppscotch: ## Start Hoppscotch self-hosted API client (F8.01 — http://localhost:3100)
 	docker compose --profile hoppscotch up
 
@@ -130,7 +154,7 @@ bruno-test-collection: ## Run Bruno tests for a specific collection (e.g. make b
 	COLLECTION=$(COLLECTION) bash scripts/bruno-test.sh
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -154,7 +178,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@
 ##   docker compose --profile cloudbeaver up -d       # CloudBeaver → http://localhost:8083
 ##   docker compose --profile db-viewer up -d         # Both viewers (Adminer + CloudBeaver)
 ##
+## AI / RAG (F9):
+##   docker compose --profile ai up -d                 # ChromaDB + OpenRAG (AI layer)
+##
 ## API Clients (F8):
 ##   docker compose --profile hoppscotch up -d        # Hoppscotch → http://localhost:3100
 ##
@@ -181,6 +184,42 @@ services:
     restart: unless-stopped
 
   # --------------------------------------------------------------------------
+  # ChromaDB – Vector database for RAG (F9.01)
+  # Access: http://localhost:8000
+  # --------------------------------------------------------------------------
+  chromadb:
+    image: chromadb/chroma:latest
+    profiles: ["ai", "openrag"]
+    container_name: stubrix-chromadb
+    ports:
+      - "${CHROMADB_PORT:-8000}:8000"
+    volumes:
+      - chromadb_data:/chroma/chroma
+    environment:
+      IS_PERSISTENT: "TRUE"
+      ANONYMIZED_TELEMETRY: "FALSE"
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # OpenRAG – RAG query service (F9.01)
+  # Access: http://localhost:8888
+  # --------------------------------------------------------------------------
+  openrag:
+    image: ghcr.io/openrag/openrag:latest
+    profiles: ["ai", "openrag"]
+    container_name: stubrix-openrag
+    ports:
+      - "${OPENRAG_PORT:-8888}:8888"
+    environment:
+      CHROMA_HOST: chromadb
+      CHROMA_PORT: 8000
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OLLAMA_HOST: ${OLLAMA_HOST:-}
+    depends_on:
+      - chromadb
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
   # Hoppscotch – Self-Hosted API Client (F8.01)
   # Access: http://localhost:3100
   # --------------------------------------------------------------------------
@@ -213,3 +252,4 @@ volumes:
   pg_data:
   mysql_data:
   cloudbeaver_data:
+  chromadb_data:

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -14,6 +14,8 @@ import { ImportModule } from './import/import.module';
 import { StatefulMocksModule } from './stateful-mocks/stateful-mocks.module';
 import { LintModule } from './governance/lint/lint.module';
 import { CoverageModule } from './coverage/coverage.module';
+import { ScenariosModule } from './scenarios/scenarios.module';
+import { IntelligenceModule } from './intelligence/intelligence.module';
 
 export function setupSwagger(app: any) {
   const config = new DocumentBuilder()
@@ -30,6 +32,8 @@ export function setupSwagger(app: any) {
     .addTag('stateful-mocks', 'Stateful mocking with DB sync')
     .addTag('governance', 'API linting and spec governance')
     .addTag('coverage', 'Mock coverage analysis')
+    .addTag('scenarios', 'Time Machine — scenario capture & restore')
+    .addTag('intelligence', 'AI-powered mock generation and RAG queries')
     .addTag('status', 'System status')
     .addServer('http://localhost:9090', 'Development server')
     .addServer('https://api.stubrix.com', 'Production server')
@@ -75,6 +79,8 @@ export function setupSwagger(app: any) {
     StatefulMocksModule,
     LintModule,
     CoverageModule,
+    ScenariosModule,
+    IntelligenceModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/intelligence/intelligence.controller.ts
+++ b/packages/api/src/intelligence/intelligence.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { IntelligenceService } from './intelligence.service';
+import type { RagQueryResult, MockSuggestion, DataSuggestion } from './intelligence.service';
+
+export class RagQueryDto {
+  @IsString()
+  question: string;
+}
+
+export class SuggestMockDto {
+  @IsString()
+  description: string;
+}
+
+export class SuggestDataDto {
+  @IsString()
+  description: string;
+}
+
+@ApiTags('intelligence')
+@Controller('api/intelligence')
+export class IntelligenceController {
+  constructor(private readonly service: IntelligenceService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check OpenRAG availability' })
+  health() {
+    return this.service.healthCheck();
+  }
+
+  @Post('query')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Ask a natural language question about mocks, docs or schemas' })
+  async query(@Body() dto: RagQueryDto): Promise<RagQueryResult> {
+    return this.service.query(dto.question);
+  }
+
+  @Post('suggest/mock')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Generate a WireMock mapping from natural language description' })
+  async suggestMock(@Body() dto: SuggestMockDto): Promise<MockSuggestion> {
+    return this.service.suggestMock(dto.description);
+  }
+
+  @Post('suggest/data')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Generate SQL seed data from natural language description' })
+  async suggestData(@Body() dto: SuggestDataDto): Promise<DataSuggestion> {
+    return this.service.suggestData(dto.description);
+  }
+
+  @Post('index')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Index all current mocks into the RAG vector store' })
+  async index() {
+    return this.service.indexMocks();
+  }
+}

--- a/packages/api/src/intelligence/intelligence.module.ts
+++ b/packages/api/src/intelligence/intelligence.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { IntelligenceController } from './intelligence.controller';
+import { IntelligenceService } from './intelligence.service';
+
+@Module({
+  controllers: [IntelligenceController],
+  providers: [IntelligenceService],
+  exports: [IntelligenceService],
+})
+export class IntelligenceModule {}

--- a/packages/api/src/intelligence/intelligence.service.ts
+++ b/packages/api/src/intelligence/intelligence.service.ts
@@ -1,0 +1,201 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface RagDocument {
+  id: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RagQueryResult {
+  answer: string;
+  sources: Array<{ id: string; content: string; score: number }>;
+  model?: string;
+}
+
+export interface MockSuggestion {
+  method: string;
+  urlPath: string;
+  responseStatus: number;
+  responseBody: string;
+  responseHeaders: Record<string, string>;
+  reasoning?: string;
+}
+
+export interface DataSuggestion {
+  sql: string;
+  tableName: string;
+  rows: number;
+  reasoning?: string;
+}
+
+@Injectable()
+export class IntelligenceService {
+  private readonly logger = new Logger(IntelligenceService.name);
+  private readonly openragUrl: string;
+  private readonly mappingsDir: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.openragUrl = this.config.get<string>('OPENRAG_URL') ?? 'http://localhost:8888';
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.mappingsDir = path.join(mocksDir, 'mappings');
+  }
+
+  async query(question: string): Promise<RagQueryResult> {
+    try {
+      const res = await fetch(`${this.openragUrl}/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: question }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!res.ok) {
+        throw new Error(`OpenRAG returned HTTP ${res.status}`);
+      }
+
+      return (await res.json()) as RagQueryResult;
+    } catch (err) {
+      this.logger.warn(`OpenRAG unavailable: ${(err as Error).message} — returning stub`);
+      return this.stubQueryResult(question);
+    }
+  }
+
+  async suggestMock(description: string): Promise<MockSuggestion> {
+    const context = this.buildMockContext();
+
+    try {
+      const res = await fetch(`${this.openragUrl}/generate/mock`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description, context }),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
+      return (await res.json()) as MockSuggestion;
+    } catch {
+      return this.heuristicMockSuggestion(description);
+    }
+  }
+
+  async suggestData(description: string): Promise<DataSuggestion> {
+    try {
+      const res = await fetch(`${this.openragUrl}/generate/data`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description }),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
+      return (await res.json()) as DataSuggestion;
+    } catch {
+      return this.heuristicDataSuggestion(description);
+    }
+  }
+
+  async indexMocks(): Promise<{ indexed: number }> {
+    const docs = this.loadMockDocuments();
+    if (docs.length === 0) return { indexed: 0 };
+
+    try {
+      const res = await fetch(`${this.openragUrl}/index`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documents: docs }),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
+      const result = (await res.json()) as { indexed?: number };
+      this.logger.log(`Indexed ${result.indexed ?? docs.length} mock documents into RAG`);
+      return { indexed: result.indexed ?? docs.length };
+    } catch (err) {
+      this.logger.warn(`RAG index unavailable: ${(err as Error).message}`);
+      return { indexed: 0 };
+    }
+  }
+
+  async healthCheck(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.openragUrl}/health`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return { available: res.ok, url: this.openragUrl };
+    } catch {
+      return { available: false, url: this.openragUrl };
+    }
+  }
+
+  private loadMockDocuments(): RagDocument[] {
+    if (!fs.existsSync(this.mappingsDir)) return [];
+    return fs
+      .readdirSync(this.mappingsDir)
+      .filter((f) => f.endsWith('.json'))
+      .flatMap((f) => {
+        try {
+          const raw = fs.readFileSync(path.join(this.mappingsDir, f), 'utf-8');
+          const m = JSON.parse(raw) as Record<string, unknown>;
+          return [{
+            id: f.replace('.json', ''),
+            content: JSON.stringify(m),
+            metadata: { filename: f, type: 'wiremock-mapping' },
+          }];
+        } catch {
+          return [];
+        }
+      });
+  }
+
+  private buildMockContext(): string {
+    const docs = this.loadMockDocuments();
+    return docs.slice(0, 5).map((d) => d.content).join('\n\n');
+  }
+
+  private stubQueryResult(question: string): RagQueryResult {
+    return {
+      answer: `[OpenRAG offline] Could not answer: "${question}". Start OpenRAG with: make ai-up`,
+      sources: [],
+      model: 'stub',
+    };
+  }
+
+  private heuristicMockSuggestion(description: string): MockSuggestion {
+    const lower = description.toLowerCase();
+    const method = lower.includes('creat') || lower.includes('post')
+      ? 'POST'
+      : lower.includes('updat') || lower.includes('put')
+      ? 'PUT'
+      : lower.includes('delet')
+      ? 'DELETE'
+      : 'GET';
+
+    const words = description.match(/\/[a-z0-9_/-]+/i);
+    const urlPath = words?.[0] ?? '/api/resource';
+
+    return {
+      method,
+      urlPath,
+      responseStatus: method === 'POST' ? 201 : method === 'DELETE' ? 204 : 200,
+      responseBody: JSON.stringify({ message: 'success', data: {} }, null, 2),
+      responseHeaders: { 'Content-Type': 'application/json' },
+      reasoning: 'Heuristic suggestion (OpenRAG offline)',
+    };
+  }
+
+  private heuristicDataSuggestion(description: string): DataSuggestion {
+    const words = description.match(/\b[a-z_]+\b/gi) ?? ['records'];
+    const tableName = words.find((w) => w.length > 3) ?? 'table';
+
+    return {
+      sql: `INSERT INTO ${tableName} (id, created_at) VALUES (gen_random_uuid(), NOW());`,
+      tableName,
+      rows: 10,
+      reasoning: 'Heuristic suggestion (OpenRAG offline)',
+    };
+  }
+}

--- a/packages/api/src/scenarios/scenario.types.ts
+++ b/packages/api/src/scenarios/scenario.types.ts
@@ -1,0 +1,31 @@
+export interface ScenarioConfig {
+  mocksDir?: string;
+  dbEngine?: string;
+  dbName?: string;
+  env?: Record<string, string>;
+}
+
+export interface ScenarioMeta {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  tags?: string[];
+  config: ScenarioConfig;
+}
+
+export interface ScenarioBundle {
+  meta: ScenarioMeta;
+  mocks: Record<string, unknown>[];
+  dbSnapshot?: string;
+}
+
+export interface ScenarioDiff {
+  scenarioA: string;
+  scenarioB: string;
+  addedMocks: string[];
+  removedMocks: string[];
+  modifiedMocks: string[];
+  dbChanged: boolean;
+  summary: string;
+}

--- a/packages/api/src/scenarios/scenarios.controller.ts
+++ b/packages/api/src/scenarios/scenarios.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { IsString, IsOptional, IsArray } from 'class-validator';
+import { ScenariosService } from './scenarios.service';
+import type { ScenarioBundle, ScenarioMeta, ScenarioDiff, ScenarioConfig } from './scenario.types';
+
+export class CaptureScenarioDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  config?: ScenarioConfig;
+}
+
+@ApiTags('scenarios')
+@Controller('api/scenarios')
+export class ScenariosController {
+  constructor(private readonly service: ScenariosService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all captured scenarios' })
+  list(): ScenarioMeta[] {
+    return this.service.listScenarios();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a scenario bundle by ID' })
+  @ApiParam({ name: 'id', description: 'Scenario UUID' })
+  get(@Param('id') id: string): ScenarioBundle {
+    return this.service.getScenario(id);
+  }
+
+  @Post('capture')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Capture current environment state as a scenario' })
+  capture(@Body() dto: CaptureScenarioDto): ScenarioBundle {
+    return this.service.capture(dto.name, dto.description, dto.tags, dto.config);
+  }
+
+  @Post(':id/restore')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Restore environment from a scenario' })
+  @ApiParam({ name: 'id', description: 'Scenario UUID' })
+  restore(@Param('id') id: string): { restored: number; name: string } {
+    return this.service.restore(id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a scenario' })
+  @ApiParam({ name: 'id', description: 'Scenario UUID' })
+  delete(@Param('id') id: string): void {
+    this.service.deleteScenario(id);
+  }
+
+  @Get(':idA/diff/:idB')
+  @ApiOperation({ summary: 'Compare two scenarios and show differences' })
+  @ApiParam({ name: 'idA', description: 'First scenario UUID' })
+  @ApiParam({ name: 'idB', description: 'Second scenario UUID' })
+  diff(@Param('idA') idA: string, @Param('idB') idB: string): ScenarioDiff {
+    return this.service.diff(idA, idB);
+  }
+}

--- a/packages/api/src/scenarios/scenarios.module.ts
+++ b/packages/api/src/scenarios/scenarios.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ScenariosController } from './scenarios.controller';
+import { ScenariosService } from './scenarios.service';
+
+@Module({
+  controllers: [ScenariosController],
+  providers: [ScenariosService],
+  exports: [ScenariosService],
+})
+export class ScenariosModule {}

--- a/packages/api/src/scenarios/scenarios.service.ts
+++ b/packages/api/src/scenarios/scenarios.service.ts
@@ -1,0 +1,189 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  ScenarioBundle,
+  ScenarioMeta,
+  ScenarioDiff,
+  ScenarioConfig,
+} from './scenario.types';
+
+@Injectable()
+export class ScenariosService {
+  private readonly logger = new Logger(ScenariosService.name);
+  private readonly scenariosDir: string;
+  private readonly mappingsDir: string;
+
+  constructor(private readonly config: ConfigService) {
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.mappingsDir = path.join(mocksDir, 'mappings');
+    this.scenariosDir = path.join(mocksDir, 'scenarios');
+    fs.mkdirSync(this.scenariosDir, { recursive: true });
+  }
+
+  listScenarios(): ScenarioMeta[] {
+    return fs
+      .readdirSync(this.scenariosDir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => {
+        try {
+          const raw = fs.readFileSync(path.join(this.scenariosDir, f), 'utf-8');
+          const bundle = JSON.parse(raw) as ScenarioBundle;
+          return bundle.meta;
+        } catch {
+          return null;
+        }
+      })
+      .filter((m): m is ScenarioMeta => m !== null)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  getScenario(id: string): ScenarioBundle {
+    const filePath = this.resolveFile(id);
+    if (!fs.existsSync(filePath)) {
+      throw new NotFoundException(`Scenario not found: ${id}`);
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as ScenarioBundle;
+  }
+
+  capture(
+    name: string,
+    description?: string,
+    tags?: string[],
+    config: ScenarioConfig = {},
+  ): ScenarioBundle {
+    const mocks = this.captureMocks();
+    const id = uuidv4();
+    const meta: ScenarioMeta = {
+      id,
+      name,
+      description,
+      createdAt: new Date().toISOString(),
+      tags,
+      config,
+    };
+
+    const bundle: ScenarioBundle = { meta, mocks };
+    const slug = name.replace(/[^a-z0-9]/gi, '_').toLowerCase().slice(0, 30);
+    const filename = `${slug}_${id}.json`;
+    fs.writeFileSync(
+      path.join(this.scenariosDir, filename),
+      JSON.stringify(bundle, null, 2),
+    );
+
+    this.logger.log(`Scenario captured: ${name} (${id}) — ${mocks.length} mocks`);
+    return bundle;
+  }
+
+  restore(id: string): { restored: number; name: string } {
+    const bundle = this.getScenario(id);
+    fs.mkdirSync(this.mappingsDir, { recursive: true });
+
+    const existing = fs.existsSync(this.mappingsDir)
+      ? fs.readdirSync(this.mappingsDir).filter((f) => f.endsWith('.json'))
+      : [];
+    for (const f of existing) {
+      fs.unlinkSync(path.join(this.mappingsDir, f));
+    }
+
+    for (const mock of bundle.mocks) {
+      const mockId = (mock as { id?: string }).id ?? uuidv4();
+      const filename = `scenario_${bundle.meta.id}_${mockId}.json`;
+      fs.writeFileSync(path.join(this.mappingsDir, filename), JSON.stringify(mock, null, 2));
+    }
+
+    this.logger.log(`Scenario restored: ${bundle.meta.name} — ${bundle.mocks.length} mocks`);
+    return { restored: bundle.mocks.length, name: bundle.meta.name };
+  }
+
+  deleteScenario(id: string): void {
+    const filePath = this.resolveFile(id);
+    if (!fs.existsSync(filePath)) {
+      throw new NotFoundException(`Scenario not found: ${id}`);
+    }
+    fs.unlinkSync(filePath);
+    this.logger.log(`Scenario deleted: ${id}`);
+  }
+
+  diff(idA: string, idB: string): ScenarioDiff {
+    const a = this.getScenario(idA);
+    const b = this.getScenario(idB);
+
+    const getMockKeys = (bundle: ScenarioBundle): Map<string, string> => {
+      const map = new Map<string, string>();
+      for (const mock of bundle.mocks) {
+        const m = mock as { request?: { method?: string; urlPath?: string; url?: string } };
+        const key = `${m.request?.method}:${m.request?.urlPath ?? m.request?.url}`;
+        map.set(key, JSON.stringify(mock));
+      }
+      return map;
+    };
+
+    const aMap = getMockKeys(a);
+    const bMap = getMockKeys(b);
+
+    const added = [...bMap.keys()].filter((k) => !aMap.has(k));
+    const removed = [...aMap.keys()].filter((k) => !bMap.has(k));
+    const modified = [...aMap.keys()].filter(
+      (k) => bMap.has(k) && aMap.get(k) !== bMap.get(k),
+    );
+
+    const parts: string[] = [];
+    if (added.length) parts.push(`+${added.length} mocks`);
+    if (removed.length) parts.push(`-${removed.length} mocks`);
+    if (modified.length) parts.push(`~${modified.length} modified`);
+
+    return {
+      scenarioA: a.meta.name,
+      scenarioB: b.meta.name,
+      addedMocks: added,
+      removedMocks: removed,
+      modifiedMocks: modified,
+      dbChanged: Boolean(a.meta.config.dbEngine || b.meta.config.dbEngine),
+      summary: parts.length ? parts.join(', ') : 'No differences',
+    };
+  }
+
+  private captureMocks(): Record<string, unknown>[] {
+    if (!fs.existsSync(this.mappingsDir)) return [];
+    return fs
+      .readdirSync(this.mappingsDir)
+      .filter((f) => f.endsWith('.json'))
+      .flatMap((f) => {
+        try {
+          const raw = fs.readFileSync(path.join(this.mappingsDir, f), 'utf-8');
+          return [JSON.parse(raw) as Record<string, unknown>];
+        } catch {
+          return [];
+        }
+      });
+  }
+
+  private resolveFile(id: string): string {
+    const files = fs.existsSync(this.scenariosDir)
+      ? fs.readdirSync(this.scenariosDir).filter((f) => f.endsWith('.json'))
+      : [];
+
+    const match = files.find((f) => {
+      try {
+        const raw = fs.readFileSync(path.join(this.scenariosDir, f), 'utf-8');
+        const b = JSON.parse(raw) as ScenarioBundle;
+        return b.meta.id === id;
+      } catch {
+        return false;
+      }
+    });
+
+    return match
+      ? path.join(this.scenariosDir, match)
+      : path.join(this.scenariosDir, `${id}.json`);
+  }
+}

--- a/packages/mcp/stubrix-mcp/src/index.js
+++ b/packages/mcp/stubrix-mcp/src/index.js
@@ -849,6 +849,120 @@ server.tool(
 );
 
 // ===========================================================================
+// Time Machine — Scenario Capture & Restore (F11)
+// ===========================================================================
+
+server.tool(
+  "scenario_list",
+  "List all captured Time Machine scenarios.",
+  {},
+  async () => api("/api/scenarios"),
+);
+
+server.tool(
+  "scenario_capture",
+  "Capture current environment state (mocks + config) as a named scenario.",
+  {
+    name: z.string().describe("Scenario name"),
+    description: z.string().optional().describe("Optional description"),
+    tags: z.array(z.string()).optional().describe("Optional tags"),
+  },
+  async ({ name, description, tags }) =>
+    api("/api/scenarios/capture", {
+      method: "POST",
+      body: JSON.stringify({ name, description, tags }),
+    }),
+);
+
+server.tool(
+  "scenario_restore",
+  "Restore environment from a previously captured scenario.",
+  {
+    id: z.string().describe("Scenario UUID"),
+  },
+  async ({ id }) =>
+    api(`/api/scenarios/${id}/restore`, { method: "POST" }),
+);
+
+server.tool(
+  "scenario_diff",
+  "Compare two scenarios and show differences in mocks and configuration.",
+  {
+    idA: z.string().describe("First scenario UUID"),
+    idB: z.string().describe("Second scenario UUID"),
+  },
+  async ({ idA, idB }) => api(`/api/scenarios/${idA}/diff/${idB}`),
+);
+
+server.tool(
+  "scenario_delete",
+  "Delete a captured scenario by ID.",
+  {
+    id: z.string().describe("Scenario UUID to delete"),
+  },
+  async ({ id }) =>
+    api(`/api/scenarios/${id}`, { method: "DELETE" }),
+);
+
+// ===========================================================================
+// Intelligence — OpenRAG + MCP AI Layer (F9)
+// ===========================================================================
+
+server.tool(
+  "rag_query",
+  "Ask a natural language question about mocks, docs, or DB schemas using the RAG intelligence layer.",
+  {
+    question: z.string().describe("Natural language question"),
+  },
+  async ({ question }) =>
+    api("/api/intelligence/query", {
+      method: "POST",
+      body: JSON.stringify({ question }),
+    }),
+);
+
+server.tool(
+  "rag_suggest_mock",
+  "Generate a WireMock mapping suggestion from a natural language endpoint description.",
+  {
+    description: z.string().describe("Natural language description, e.g. 'GET /users returns list of users with 200'"),
+  },
+  async ({ description }) =>
+    api("/api/intelligence/suggest/mock", {
+      method: "POST",
+      body: JSON.stringify({ description }),
+    }),
+);
+
+server.tool(
+  "rag_suggest_data",
+  "Generate SQL seed data from a natural language description.",
+  {
+    description: z.string().describe("Natural language description, e.g. 'Insert 10 users into users table'"),
+  },
+  async ({ description }) =>
+    api("/api/intelligence/suggest/data", {
+      method: "POST",
+      body: JSON.stringify({ description }),
+    }),
+);
+
+server.tool(
+  "rag_index",
+  "Index all current mock mappings into the RAG vector store for AI queries.",
+  {},
+  async () =>
+    api("/api/intelligence/index", { method: "POST" }),
+);
+
+server.tool(
+  "rag_health",
+  "Check if the OpenRAG AI service is available.",
+  {},
+  async () => api("/api/intelligence/health"),
+);
+
+// ===========================================================================
 // Governance — Spectral Lint (F12)
 // ===========================================================================
 


### PR DESCRIPTION
## 📝 Descrição

Implementação completa do milestone **v1.7.0 — Intelligence & Time Machine** cobrindo 2 épicos.

## 🔗 Issues Relacionadas

Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #90
Closes #91
Closes #92
Closes #93
Closes #94
Closes #95
Closes #96
Closes #31
Closes #35

## 🎯 O que foi implementado

### F9 — OpenRAG + MCP Intelligence Layer (#66-#72)
- **F9.01** Docker Compose profile `ai` — ChromaDB (:8000) + OpenRAG (:8888) com volume persistente
- **F9.02-03** `IntelligenceService` wrapping OpenRAG REST API com fallback heurístico quando offline
- **F9.04** `POST /api/intelligence/suggest/mock` — linguagem natural → WireMock mapping
- **F9.05** `POST /api/intelligence/suggest/data` — linguagem natural → SQL seed data
- **F9.06** 5 MCP tools: `rag_query`, `rag_suggest_mock`, `rag_suggest_data`, `rag_index`, `rag_health`
- **F9.07** `IntelligenceController` com endpoints: `/query`, `/suggest/mock`, `/suggest/data`, `/index`, `/health`
- Makefile: `make ai-up`, `ai-down`, `ai-logs`

### F11 — Time Machine: Scenario Capture & Restore (#90-#96)
- **F11.01** `ScenarioBundle` + `ScenarioMeta` + `ScenarioDiff` TypeScript types
- **F11.02** `ScenariosService.capture()` — snapshot de todos os mappings + config
- **F11.03** `ScenariosService.restore()` — restaura mappings a partir de bundle
- **F11.04** `ScenariosController`:
  - `GET /api/scenarios` — listar cenários
  - `GET /api/scenarios/:id` — obter bundle
  - `POST /api/scenarios/capture` — capturar estado atual
  - `POST /api/scenarios/:id/restore` — restaurar
  - `DELETE /api/scenarios/:id` — deletar
- **F11.05** `ScenariosService.diff()` — compara dois bundles (added/removed/modified)
- **F11.06** Makefile targets: `scenario-save NAME=`, `scenario-restore ID=`, `scenario-list`
- **F11.07** 5 MCP tools: `scenario_list`, `scenario_capture`, `scenario_restore`, `scenario_diff`, `scenario_delete`