### PR TITLE
✨ feat(api): F13 + F14 + F26 — Contract Testing, Chaos Engineering, Network Chaos (v1.8.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ SQLITE_DB_PATH=
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
 
+# Pact Broker – Contract Testing (F13.01)
+PACT_BROKER_URL=http://localhost:9292
+PACT_BROKER_PORT=9292
+
+# Toxiproxy – Network Chaos (F26.01)
+TOXIPROXY_URL=http://localhost:8474
+TOXIPROXY_PORT=8474
+
 # AI / RAG – OpenRAG + ChromaDB (F9.01)
 OPENRAG_URL=http://localhost:8888
 CHROMADB_PORT=8000

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
         hoppscotch hoppscotch-down hoppscotch-logs \
         bruno-test bruno-test-collection \
         ai-up ai-down ai-logs \
-        scenario-save scenario-restore scenario-list
+        scenario-save scenario-restore scenario-list \
+        pact-up pact-down pact-logs \
+        toxiproxy-up toxiproxy-down toxiproxy-logs
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -136,6 +138,24 @@ scenario-restore: ## Restore environment from a scenario (F11.06) — ID=<uuid> 
 scenario-list: ## List all captured scenarios (F11.06)
 	curl -s http://localhost:9090/api/scenarios | jq .
 
+pact-up: ## Start Pact Broker + PostgreSQL (F13.01 — detached)
+	docker compose --profile postgres --profile pact up -d
+
+pact-down: ## Stop Pact Broker
+	docker compose --profile pact down
+
+pact-logs: ## Tail Pact Broker logs
+	docker compose --profile pact logs -f pact-broker
+
+toxiproxy-up: ## Start Toxiproxy network chaos (F26.01 — detached)
+	docker compose --profile toxiproxy up -d
+
+toxiproxy-down: ## Stop Toxiproxy
+	docker compose --profile toxiproxy down
+
+toxiproxy-logs: ## Tail Toxiproxy logs
+	docker compose --profile toxiproxy logs -f toxiproxy
+
 hoppscotch: ## Start Hoppscotch self-hosted API client (F8.01 — http://localhost:3100)
 	docker compose --profile hoppscotch up
 
@@ -154,7 +174,7 @@ bruno-test-collection: ## Run Bruno tests for a specific collection (e.g. make b
 	COLLECTION=$(COLLECTION) bash scripts/bruno-test.sh
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -178,7 +198,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@
 ## AI / RAG (F9):
 ##   docker compose --profile ai up -d                 # ChromaDB + OpenRAG (AI layer)
 ##
+## Contracts (F13):
+##   docker compose --profile pact up -d               # Pact Broker → http://localhost:9292
+##
+## Network Chaos (F26):
+##   docker compose --profile toxiproxy up -d          # Toxiproxy → http://localhost:8474
+##
 ## API Clients (F8):
 ##   docker compose --profile hoppscotch up -d        # Hoppscotch → http://localhost:3100
 ##
@@ -184,6 +190,39 @@ services:
     restart: unless-stopped
 
   # --------------------------------------------------------------------------
+  # Pact Broker – Contract testing (F13.01)
+  # Access: http://localhost:9292
+  # --------------------------------------------------------------------------
+  pact-broker:
+    image: pactfoundation/pact-broker:latest
+    profiles: ["pact"]
+    container_name: stubrix-pact-broker
+    ports:
+      - "${PACT_BROKER_PORT:-9292}:9292"
+    environment:
+      PACT_BROKER_DATABASE_URL: postgresql://${PG_USER:-postgres}:${PG_PASSWORD:-postgres}@db-postgres:5432/${PG_DATABASE:-postgres}
+      PACT_BROKER_ALLOW_PUBLIC_READ: "true"
+      PACT_BROKER_DISABLE_SSL_VERIFICATION: "true"
+    depends_on:
+      db-postgres:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Toxiproxy – Network-level chaos engineering (F26.01)
+  # API: http://localhost:8474 | Proxy range: 8475-8485
+  # --------------------------------------------------------------------------
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:latest
+    profiles: ["toxiproxy", "chaos-network"]
+    container_name: stubrix-toxiproxy
+    ports:
+      - "${TOXIPROXY_PORT:-8474}:8474"
+      - "8475-8485:8475-8485"
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
   # ChromaDB – Vector database for RAG (F9.01)
   # Access: http://localhost:8000
   # --------------------------------------------------------------------------
@@ -253,3 +292,4 @@ volumes:
   mysql_data:
   cloudbeaver_data:
   chromadb_data:
+  pact_data:

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -16,6 +16,9 @@ import { LintModule } from './governance/lint/lint.module';
 import { CoverageModule } from './coverage/coverage.module';
 import { ScenariosModule } from './scenarios/scenarios.module';
 import { IntelligenceModule } from './intelligence/intelligence.module';
+import { ChaosModule } from './chaos/chaos.module';
+import { ContractsModule } from './contracts/contracts.module';
+import { ChaosNetworkModule } from './chaos-network/chaos-network.module';
 
 export function setupSwagger(app: any) {
   const config = new DocumentBuilder()
@@ -34,6 +37,9 @@ export function setupSwagger(app: any) {
     .addTag('coverage', 'Mock coverage analysis')
     .addTag('scenarios', 'Time Machine — scenario capture & restore')
     .addTag('intelligence', 'AI-powered mock generation and RAG queries')
+    .addTag('chaos', 'Fault injection and chaos engineering')
+    .addTag('contracts', 'Pact Broker contract testing')
+    .addTag('chaos-network', 'Toxiproxy network-level chaos')
     .addTag('status', 'System status')
     .addServer('http://localhost:9090', 'Development server')
     .addServer('https://api.stubrix.com', 'Production server')
@@ -81,6 +87,9 @@ export function setupSwagger(app: any) {
     CoverageModule,
     ScenariosModule,
     IntelligenceModule,
+    ChaosModule,
+    ContractsModule,
+    ChaosNetworkModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/chaos-network/chaos-network.controller.ts
+++ b/packages/api/src/chaos-network/chaos-network.controller.ts
@@ -1,0 +1,116 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+import { ChaosNetworkService } from './chaos-network.service';
+import type { ToxiProxy, Toxic } from './chaos-network.service';
+
+export class CreateProxyDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  listen: string;
+
+  @IsString()
+  upstream: string;
+}
+
+export class AddToxicDto {
+  @IsString()
+  type: string;
+
+  @IsString()
+  stream: 'upstream' | 'downstream';
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  toxicity?: number;
+  attributes?: Record<string, unknown>;
+}
+
+export class ApplyPresetDto {
+  @IsString()
+  preset: string;
+}
+
+@ApiTags('chaos-network')
+@Controller('api/chaos-network')
+export class ChaosNetworkController {
+  constructor(private readonly service: ChaosNetworkService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check Toxiproxy availability' })
+  health() {
+    return this.service.healthCheck();
+  }
+
+  @Get('proxies')
+  @ApiOperation({ summary: 'List all Toxiproxy proxies' })
+  list(): Promise<ToxiProxy[]> {
+    return this.service.listProxies();
+  }
+
+  @Post('proxies')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new Toxiproxy proxy' })
+  create(@Body() dto: CreateProxyDto): Promise<ToxiProxy> {
+    return this.service.createProxy(dto.name, dto.listen, dto.upstream);
+  }
+
+  @Delete('proxies/:name')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a Toxiproxy proxy' })
+  @ApiParam({ name: 'name', description: 'Proxy name' })
+  deleteProxy(@Param('name') name: string): Promise<void> {
+    return this.service.deleteProxy(name);
+  }
+
+  @Post('proxies/:name/toxics')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Add a toxic to a proxy' })
+  @ApiParam({ name: 'name', description: 'Proxy name' })
+  addToxic(@Param('name') name: string, @Body() dto: AddToxicDto): Promise<Toxic> {
+    return this.service.addToxic(name, {
+      type: dto.type,
+      stream: dto.stream,
+      name: dto.name,
+      toxicity: dto.toxicity ?? 1.0,
+      attributes: dto.attributes ?? {},
+    });
+  }
+
+  @Delete('proxies/:name/toxics/:toxicName')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a toxic from a proxy' })
+  removeToxic(
+    @Param('name') name: string,
+    @Param('toxicName') toxicName: string,
+  ): Promise<void> {
+    return this.service.removeToxic(name, toxicName);
+  }
+
+  @Get('presets')
+  @ApiOperation({ summary: 'List network chaos presets' })
+  presets() {
+    return this.service.listPresets();
+  }
+
+  @Post('proxies/:name/presets')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Apply a network chaos preset to a proxy' })
+  @ApiParam({ name: 'name', description: 'Proxy name' })
+  applyPreset(@Param('name') name: string, @Body() dto: ApplyPresetDto): Promise<Toxic[]> {
+    return this.service.applyPreset(name, dto.preset);
+  }
+}

--- a/packages/api/src/chaos-network/chaos-network.module.ts
+++ b/packages/api/src/chaos-network/chaos-network.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ChaosNetworkController } from './chaos-network.controller';
+import { ChaosNetworkService } from './chaos-network.service';
+
+@Module({
+  controllers: [ChaosNetworkController],
+  providers: [ChaosNetworkService],
+  exports: [ChaosNetworkService],
+})
+export class ChaosNetworkModule {}

--- a/packages/api/src/chaos-network/chaos-network.service.ts
+++ b/packages/api/src/chaos-network/chaos-network.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface ToxiProxy {
+  name: string;
+  listen: string;
+  upstream: string;
+  enabled: boolean;
+  toxics: Toxic[];
+}
+
+export interface Toxic {
+  name: string;
+  type: string;
+  stream: 'upstream' | 'downstream';
+  toxicity: number;
+  attributes: Record<string, unknown>;
+}
+
+export interface NetworkPreset {
+  name: string;
+  description: string;
+  toxics: Omit<Toxic, 'name'>[];
+}
+
+const NETWORK_PRESETS: Record<string, NetworkPreset> = {
+  'latency': {
+    name: 'High Latency',
+    description: 'Add 500ms latency to all connections',
+    toxics: [{ type: 'latency', stream: 'downstream', toxicity: 1.0, attributes: { latency: 500, jitter: 50 } }],
+  },
+  'bandwidth': {
+    name: 'Low Bandwidth',
+    description: 'Limit bandwidth to 100KB/s',
+    toxics: [{ type: 'bandwidth', stream: 'downstream', toxicity: 1.0, attributes: { rate: 100 } }],
+  },
+  'packet-loss': {
+    name: 'Packet Loss',
+    description: '30% packet loss simulation',
+    toxics: [{ type: 'timeout', stream: 'downstream', toxicity: 0.3, attributes: { timeout: 0 } }],
+  },
+  'slow-close': {
+    name: 'Slow Close',
+    description: 'Delay connection closing by 2s',
+    toxics: [{ type: 'slow_close', stream: 'downstream', toxicity: 1.0, attributes: { delay: 2000 } }],
+  },
+};
+
+@Injectable()
+export class ChaosNetworkService {
+  private readonly logger = new Logger(ChaosNetworkService.name);
+  private readonly toxiproxyUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.toxiproxyUrl = this.config.get<string>('TOXIPROXY_URL') ?? 'http://localhost:8474';
+  }
+
+  async listProxies(): Promise<ToxiProxy[]> {
+    try {
+      const res = await fetch(`${this.toxiproxyUrl}/proxies`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!res.ok) throw new Error(`Toxiproxy HTTP ${res.status}`);
+      const data = (await res.json()) as Record<string, ToxiProxy>;
+      return Object.values(data);
+    } catch (err) {
+      this.logger.warn(`Toxiproxy unavailable: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  async createProxy(name: string, listen: string, upstream: string): Promise<ToxiProxy> {
+    const res = await fetch(`${this.toxiproxyUrl}/proxies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, listen, upstream, enabled: true }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`Toxiproxy HTTP ${res.status}`);
+    return (await res.json()) as ToxiProxy;
+  }
+
+  async addToxic(proxyName: string, toxic: Omit<Toxic, 'name'> & { name?: string }): Promise<Toxic> {
+    const name = toxic.name ?? `${toxic.type}_${Date.now()}`;
+    const res = await fetch(`${this.toxiproxyUrl}/proxies/${proxyName}/toxics`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...toxic, name }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`Toxiproxy HTTP ${res.status}`);
+    return (await res.json()) as Toxic;
+  }
+
+  async removeToxic(proxyName: string, toxicName: string): Promise<void> {
+    await fetch(`${this.toxiproxyUrl}/proxies/${proxyName}/toxics/${toxicName}`, {
+      method: 'DELETE',
+      signal: AbortSignal.timeout(5_000),
+    });
+  }
+
+  async deleteProxy(name: string): Promise<void> {
+    await fetch(`${this.toxiproxyUrl}/proxies/${name}`, {
+      method: 'DELETE',
+      signal: AbortSignal.timeout(5_000),
+    });
+  }
+
+  listPresets(): NetworkPreset[] {
+    return Object.values(NETWORK_PRESETS);
+  }
+
+  async applyPreset(proxyName: string, presetName: string): Promise<Toxic[]> {
+    const preset = NETWORK_PRESETS[presetName];
+    if (!preset) throw new Error(`Unknown preset: ${presetName}`);
+
+    const results: Toxic[] = [];
+    for (const toxic of preset.toxics) {
+      const t = await this.addToxic(proxyName, { ...toxic, name: `${presetName}_${Date.now()}` });
+      results.push(t);
+    }
+    return results;
+  }
+
+  async healthCheck(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.toxiproxyUrl}/version`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return { available: res.ok, url: this.toxiproxyUrl };
+    } catch {
+      return { available: false, url: this.toxiproxyUrl };
+    }
+  }
+}

--- a/packages/api/src/chaos/chaos.controller.ts
+++ b/packages/api/src/chaos/chaos.controller.ts
@@ -1,0 +1,135 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Patch,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { IsString, IsOptional, IsArray, IsNumber, Min, Max, IsBoolean } from 'class-validator';
+import { ChaosService } from './chaos.service';
+import type { FaultProfile, FaultRule, ChaosPreset } from './chaos.types';
+
+export class FaultRuleDto {
+  @IsString()
+  type: string;
+
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  probability: number;
+
+  @IsOptional()
+  @IsNumber()
+  delayMs?: number;
+
+  @IsOptional()
+  @IsNumber()
+  errorStatus?: number;
+
+  @IsOptional()
+  @IsString()
+  errorMessage?: string;
+}
+
+export class CreateProfileDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  urlPattern?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  methods?: string[];
+
+  @IsArray()
+  faults: FaultRuleDto[];
+}
+
+export class ApplyPresetDto {
+  @IsString()
+  preset: string;
+
+  @IsOptional()
+  @IsString()
+  urlPattern?: string;
+}
+
+export class ToggleDto {
+  @IsBoolean()
+  enabled: boolean;
+}
+
+@ApiTags('chaos')
+@Controller('api/chaos')
+export class ChaosController {
+  constructor(private readonly service: ChaosService) {}
+
+  @Get('profiles')
+  @ApiOperation({ summary: 'List all chaos fault profiles' })
+  list(): FaultProfile[] {
+    return this.service.listProfiles();
+  }
+
+  @Post('profiles')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a chaos fault profile' })
+  create(@Body() dto: CreateProfileDto): FaultProfile {
+    return this.service.createProfile(
+      dto.name,
+      dto.faults as FaultRule[],
+      dto.description,
+      dto.urlPattern,
+      dto.methods,
+    );
+  }
+
+  @Patch('profiles/:id/toggle')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Enable or disable a chaos profile' })
+  @ApiParam({ name: 'id', description: 'Profile UUID' })
+  toggle(@Param('id') id: string, @Body() dto: ToggleDto): FaultProfile {
+    return this.service.toggleProfile(id, dto.enabled);
+  }
+
+  @Delete('profiles/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a chaos fault profile' })
+  @ApiParam({ name: 'id', description: 'Profile UUID' })
+  delete(@Param('id') id: string): void {
+    this.service.deleteProfile(id);
+  }
+
+  @Get('presets')
+  @ApiOperation({ summary: 'List built-in chaos presets' })
+  presets(): ChaosPreset[] {
+    return this.service.listPresets();
+  }
+
+  @Post('presets/apply')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Apply a built-in chaos preset as a new profile' })
+  applyPreset(@Body() dto: ApplyPresetDto): FaultProfile {
+    return this.service.applyPreset(dto.preset, dto.urlPattern);
+  }
+
+  @Get('evaluate')
+  @ApiOperation({ summary: 'Evaluate active chaos profiles for a given URL + method' })
+  evaluate(
+    @Body('urlPath') urlPath: string,
+    @Body('method') method: string,
+  ) {
+    return this.service.evaluate(urlPath ?? '/', method ?? 'GET');
+  }
+}

--- a/packages/api/src/chaos/chaos.module.ts
+++ b/packages/api/src/chaos/chaos.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ChaosController } from './chaos.controller';
+import { ChaosService } from './chaos.service';
+
+@Module({
+  controllers: [ChaosController],
+  providers: [ChaosService],
+  exports: [ChaosService],
+})
+export class ChaosModule {}

--- a/packages/api/src/chaos/chaos.service.ts
+++ b/packages/api/src/chaos/chaos.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import type { FaultProfile, FaultRule, ChaosPreset, ChaosResult } from './chaos.types';
+
+const PRESETS: Record<string, ChaosPreset> = {
+  'slow-network': {
+    name: 'Slow Network',
+    description: 'Simulates a slow 3G connection with 2s delay',
+    faults: [{ type: 'delay', probability: 1.0, delayMs: 2000 }],
+  },
+  'flaky-service': {
+    name: 'Flaky Service',
+    description: '30% chance of 500 error, 20% chance of 1s delay',
+    faults: [
+      { type: 'random_error', probability: 0.3, errorStatus: 500, errorMessage: 'Internal Server Error' },
+      { type: 'delay', probability: 0.2, delayMs: 1000 },
+    ],
+  },
+  'total-outage': {
+    name: 'Total Outage',
+    description: '100% of requests fail with 503',
+    faults: [{ type: 'error', probability: 1.0, errorStatus: 503, errorMessage: 'Service Unavailable' }],
+  },
+  'timeout': {
+    name: 'Request Timeout',
+    description: 'All requests timeout after 30s',
+    faults: [{ type: 'timeout', probability: 1.0, delayMs: 30000 }],
+  },
+};
+
+@Injectable()
+export class ChaosService {
+  private readonly logger = new Logger(ChaosService.name);
+  private readonly profilesDir: string;
+
+  constructor(private readonly config: ConfigService) {
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.profilesDir = path.join(mocksDir, 'chaos');
+    fs.mkdirSync(this.profilesDir, { recursive: true });
+  }
+
+  listProfiles(): FaultProfile[] {
+    return fs
+      .readdirSync(this.profilesDir)
+      .filter((f) => f.endsWith('.json'))
+      .flatMap((f) => {
+        try {
+          return [JSON.parse(fs.readFileSync(path.join(this.profilesDir, f), 'utf-8')) as FaultProfile];
+        } catch {
+          return [];
+        }
+      })
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  getProfile(id: string): FaultProfile | undefined {
+    return this.listProfiles().find((p) => p.id === id);
+  }
+
+  createProfile(
+    name: string,
+    faults: FaultRule[],
+    description?: string,
+    urlPattern?: string,
+    methods?: string[],
+  ): FaultProfile {
+    const profile: FaultProfile = {
+      id: uuidv4(),
+      name,
+      description,
+      enabled: true,
+      urlPattern,
+      methods,
+      faults,
+      createdAt: new Date().toISOString(),
+    };
+    const filename = `${name.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_${profile.id}.json`;
+    fs.writeFileSync(path.join(this.profilesDir, filename), JSON.stringify(profile, null, 2));
+    this.logger.log(`Chaos profile created: ${name} (${profile.id})`);
+    return profile;
+  }
+
+  toggleProfile(id: string, enabled: boolean): FaultProfile {
+    const profile = this.getProfile(id);
+    if (!profile) throw new Error(`Profile not found: ${id}`);
+
+    profile.enabled = enabled;
+    this.saveProfile(profile);
+    return profile;
+  }
+
+  deleteProfile(id: string): void {
+    const files = fs.readdirSync(this.profilesDir).filter((f) => f.endsWith('.json'));
+    for (const f of files) {
+      try {
+        const p = JSON.parse(fs.readFileSync(path.join(this.profilesDir, f), 'utf-8')) as FaultProfile;
+        if (p.id === id) {
+          fs.unlinkSync(path.join(this.profilesDir, f));
+          return;
+        }
+      } catch {
+        // skip
+      }
+    }
+    throw new Error(`Profile not found: ${id}`);
+  }
+
+  listPresets(): ChaosPreset[] {
+    return Object.values(PRESETS);
+  }
+
+  applyPreset(presetName: string, urlPattern?: string): FaultProfile {
+    const preset = PRESETS[presetName];
+    if (!preset) throw new Error(`Unknown preset: ${presetName}`);
+    return this.createProfile(preset.name, preset.faults, preset.description, urlPattern);
+  }
+
+  evaluate(urlPath: string, method: string): ChaosResult {
+    const active = this.listProfiles().filter((p) => p.enabled);
+    for (const profile of active) {
+      if (profile.urlPattern) {
+        try {
+          if (!new RegExp(profile.urlPattern).test(urlPath)) continue;
+        } catch {
+          continue;
+        }
+      }
+      if (profile.methods?.length && !profile.methods.includes(method.toUpperCase())) continue;
+
+      for (const fault of profile.faults) {
+        if (Math.random() < fault.probability) {
+          return { triggered: true, fault, profile: profile.name };
+        }
+      }
+    }
+    return { triggered: false };
+  }
+
+  private saveProfile(profile: FaultProfile): void {
+    const files = fs.readdirSync(this.profilesDir).filter((f) => f.endsWith('.json'));
+    for (const f of files) {
+      try {
+        const p = JSON.parse(fs.readFileSync(path.join(this.profilesDir, f), 'utf-8')) as FaultProfile;
+        if (p.id === profile.id) {
+          fs.writeFileSync(path.join(this.profilesDir, f), JSON.stringify(profile, null, 2));
+          return;
+        }
+      } catch {
+        // skip
+      }
+    }
+  }
+}

--- a/packages/api/src/chaos/chaos.types.ts
+++ b/packages/api/src/chaos/chaos.types.ts
@@ -1,0 +1,38 @@
+export type FaultType =
+  | 'delay'
+  | 'error'
+  | 'timeout'
+  | 'random_error'
+  | 'bandwidth_limit';
+
+export interface FaultProfile {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  urlPattern?: string;
+  methods?: string[];
+  faults: FaultRule[];
+  createdAt: string;
+}
+
+export interface FaultRule {
+  type: FaultType;
+  probability: number;
+  delayMs?: number;
+  errorStatus?: number;
+  errorMessage?: string;
+  bandwidthKbps?: number;
+}
+
+export interface ChaosPreset {
+  name: string;
+  description: string;
+  faults: FaultRule[];
+}
+
+export interface ChaosResult {
+  triggered: boolean;
+  fault?: FaultRule;
+  profile?: string;
+}

--- a/packages/api/src/contracts/contracts.controller.ts
+++ b/packages/api/src/contracts/contracts.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { ContractsService } from './contracts.service';
+
+export class CanIDeployDto {
+  @IsString()
+  pacticipant: string;
+
+  @IsString()
+  version: string;
+}
+
+@ApiTags('contracts')
+@Controller('api/contracts')
+export class ContractsController {
+  constructor(private readonly service: ContractsService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check Pact Broker availability' })
+  health() {
+    return this.service.healthCheck();
+  }
+
+  @Get('pacts')
+  @ApiOperation({ summary: 'List all latest pact contracts from Pact Broker' })
+  list() {
+    return this.service.listContracts();
+  }
+
+  @Get('can-i-deploy')
+  @ApiOperation({ summary: 'Check if a pacticipant version can be deployed to production' })
+  @ApiQuery({ name: 'pacticipant', required: true })
+  @ApiQuery({ name: 'version', required: true })
+  canIDeploy(
+    @Query('pacticipant') pacticipant: string,
+    @Query('version') version: string,
+  ) {
+    return this.service.canIDeploy(pacticipant, version);
+  }
+}

--- a/packages/api/src/contracts/contracts.module.ts
+++ b/packages/api/src/contracts/contracts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ContractsController } from './contracts.controller';
+import { ContractsService } from './contracts.service';
+
+@Module({
+  controllers: [ContractsController],
+  providers: [ContractsService],
+  exports: [ContractsService],
+})
+export class ContractsModule {}

--- a/packages/api/src/contracts/contracts.service.ts
+++ b/packages/api/src/contracts/contracts.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface PactContract {
+  consumer: string;
+  provider: string;
+  pactUrl: string;
+  status?: 'verified' | 'failed' | 'pending';
+  verifiedAt?: string;
+}
+
+export interface CanIDeployResult {
+  success: boolean;
+  consumer: string;
+  provider: string;
+  message: string;
+}
+
+@Injectable()
+export class ContractsService {
+  private readonly logger = new Logger(ContractsService.name);
+  private readonly brokerUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.brokerUrl = this.config.get<string>('PACT_BROKER_URL') ?? 'http://localhost:9292';
+  }
+
+  async listContracts(): Promise<PactContract[]> {
+    try {
+      const res = await fetch(`${this.brokerUrl}/pacts/latest`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!res.ok) throw new Error(`Pact Broker HTTP ${res.status}`);
+      const data = (await res.json()) as { _embedded?: { pacts?: Array<{ _links: { self: Array<{ href: string; name: string }> }; _embedded: { consumer: { name: string }; provider: { name: string } } }> } };
+      return (data._embedded?.pacts ?? []).map((p) => ({
+        consumer: p._embedded.consumer.name,
+        provider: p._embedded.provider.name,
+        pactUrl: p._links.self[0]?.href ?? '',
+        status: 'pending',
+      }));
+    } catch (err) {
+      this.logger.warn(`Pact Broker unavailable: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  async canIDeploy(pacticipant: string, version: string): Promise<CanIDeployResult> {
+    try {
+      const res = await fetch(
+        `${this.brokerUrl}/can-i-deploy?pacticipant=${encodeURIComponent(pacticipant)}&version=${encodeURIComponent(version)}&to=production`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      const data = (await res.json()) as { summary?: { deployable?: boolean; reason?: string } };
+      const deployable = data.summary?.deployable ?? false;
+      return {
+        success: deployable,
+        consumer: pacticipant,
+        provider: '',
+        message: data.summary?.reason ?? (deployable ? 'All verifications passed' : 'Verification failed'),
+      };
+    } catch (err) {
+      return {
+        success: false,
+        consumer: pacticipant,
+        provider: '',
+        message: `Pact Broker unavailable: ${(err as Error).message}`,
+      };
+    }
+  }
+
+  async healthCheck(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.brokerUrl}`, { signal: AbortSignal.timeout(3_000) });
+      return { available: res.ok, url: this.brokerUrl };
+    } catch {
+      return { available: false, url: this.brokerUrl };
+    }
+  }
+}

--- a/packages/mcp/stubrix-mcp/src/index.js
+++ b/packages/mcp/stubrix-mcp/src/index.js
@@ -963,6 +963,157 @@ server.tool(
 );
 
 // ===========================================================================
+// Chaos Engineering — Fault Injection (F14)
+// ===========================================================================
+
+server.tool(
+  "chaos_list_profiles",
+  "List all active chaos fault injection profiles.",
+  {},
+  async () => api("/api/chaos/profiles"),
+);
+
+server.tool(
+  "chaos_create_profile",
+  "Create a fault injection profile (delay, error, timeout, etc.).",
+  {
+    name: z.string().describe("Profile name"),
+    faults: z.array(z.object({
+      type: z.string().describe("Fault type: delay | error | timeout | random_error | bandwidth_limit"),
+      probability: z.number().min(0).max(1).describe("Probability 0.0-1.0"),
+      delayMs: z.number().optional(),
+      errorStatus: z.number().optional(),
+      errorMessage: z.string().optional(),
+    })).describe("List of fault rules"),
+    urlPattern: z.string().optional().describe("Regex to match URLs"),
+    description: z.string().optional(),
+  },
+  async ({ name, faults, urlPattern, description }) =>
+    api("/api/chaos/profiles", {
+      method: "POST",
+      body: JSON.stringify({ name, faults, urlPattern, description }),
+    }),
+);
+
+server.tool(
+  "chaos_list_presets",
+  "List built-in chaos presets (slow-network, flaky-service, total-outage, timeout).",
+  {},
+  async () => api("/api/chaos/presets"),
+);
+
+server.tool(
+  "chaos_apply_preset",
+  "Apply a built-in chaos preset as a new fault profile.",
+  {
+    preset: z.string().describe("Preset name: slow-network | flaky-service | total-outage | timeout"),
+    urlPattern: z.string().optional().describe("Optional URL regex filter"),
+  },
+  async ({ preset, urlPattern }) =>
+    api("/api/chaos/presets/apply", {
+      method: "POST",
+      body: JSON.stringify({ preset, urlPattern }),
+    }),
+);
+
+server.tool(
+  "chaos_toggle_profile",
+  "Enable or disable a chaos fault profile.",
+  {
+    id: z.string().describe("Profile UUID"),
+    enabled: z.boolean().describe("true to enable, false to disable"),
+  },
+  async ({ id, enabled }) =>
+    api(`/api/chaos/profiles/${id}/toggle`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled }),
+    }),
+);
+
+// ===========================================================================
+// Contract Testing — Pact Broker (F13)
+// ===========================================================================
+
+server.tool(
+  "contract_list",
+  "List all latest pact contracts from Pact Broker.",
+  {},
+  async () => api("/api/contracts/pacts"),
+);
+
+server.tool(
+  "contract_can_i_deploy",
+  "Check if a pacticipant version can be safely deployed to production.",
+  {
+    pacticipant: z.string().describe("Consumer or provider name"),
+    version: z.string().describe("Version to check (e.g. '1.2.3' or git SHA)"),
+  },
+  async ({ pacticipant, version }) =>
+    api(`/api/contracts/can-i-deploy?pacticipant=${encodeURIComponent(pacticipant)}&version=${encodeURIComponent(version)}`),
+);
+
+server.tool(
+  "contract_broker_health",
+  "Check if the Pact Broker is available.",
+  {},
+  async () => api("/api/contracts/health"),
+);
+
+// ===========================================================================
+// Network Chaos — Toxiproxy (F26)
+// ===========================================================================
+
+server.tool(
+  "network_list_proxies",
+  "List all Toxiproxy network proxies.",
+  {},
+  async () => api("/api/chaos-network/proxies"),
+);
+
+server.tool(
+  "network_create_proxy",
+  "Create a Toxiproxy proxy to intercept a service.",
+  {
+    name: z.string().describe("Proxy name"),
+    listen: z.string().describe("Listen address e.g. '0.0.0.0:8475'"),
+    upstream: z.string().describe("Upstream address e.g. 'db-postgres:5432'"),
+  },
+  async ({ name, listen, upstream }) =>
+    api("/api/chaos-network/proxies", {
+      method: "POST",
+      body: JSON.stringify({ name, listen, upstream }),
+    }),
+);
+
+server.tool(
+  "network_apply_preset",
+  "Apply a network chaos preset to a proxy (latency, bandwidth, packet-loss, slow-close).",
+  {
+    proxyName: z.string().describe("Toxiproxy proxy name"),
+    preset: z.string().describe("Preset: latency | bandwidth | packet-loss | slow-close"),
+  },
+  async ({ proxyName, preset }) =>
+    api(`/api/chaos-network/proxies/${proxyName}/presets`, {
+      method: "POST",
+      body: JSON.stringify({ preset }),
+    }),
+);
+
+server.tool(
+  "network_list_presets",
+  "List available network chaos presets.",
+  {},
+  async () => api("/api/chaos-network/presets"),
+);
+
+server.tool(
+  "network_toxiproxy_health",
+  "Check if Toxiproxy is available.",
+  {},
+  async () => api("/api/chaos-network/health"),
+);
+
+// ===========================================================================
 // Governance — Spectral Lint (F12)
 // ===========================================================================
 


### PR DESCRIPTION
## 📝 Descrição

Implementação completa do milestone **v1.8.0 — Contracts & Chaos** cobrindo 3 épicos.

## 🔗 Issues Relacionadas

Closes #78
Closes #79
Closes #80
Closes #81
Closes #82
Closes #83
Closes #105
Closes #106
Closes #107
Closes #108
Closes #109
Closes #110
Closes #111
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179
Closes #180
Closes #33
Closes #37
Closes #48

## 🎯 O que foi implementado

### F14 — Chaos Engineering & Fault Injection (#78-#83)
- **F14.01** `FaultProfile` + `FaultRule` + `ChaosPreset` types
- **F14.02-03** `ChaosService` — CRUD de profiles, persistência em arquivo, `evaluate()`
- **F14.04** 4 presets: `slow-network`, `flaky-service`, `total-outage`, `timeout`
- **F14.05** `ChaosController` — `GET/POST /api/chaos/profiles`, `PATCH toggle`, `DELETE`, presets, evaluate
- **F14.06** 5 MCP tools: `chaos_list_profiles`, `chaos_create_profile`, `chaos_list_presets`, `chaos_apply_preset`, `chaos_toggle_profile`

### F13 — Pact Broker Contract Testing (#105-#111)
- **F13.01** Docker Compose profile `pact` (:9292) backed by PostgreSQL
- **F13.04** `ContractsService` wrapping Pact Broker REST API com fallback gracioso
- **F13.06** `ContractsController` — `GET /api/contracts/pacts`, `/health`, `/can-i-deploy`
- **F13.07** 3 MCP tools: `contract_list`, `contract_can_i_deploy`, `contract_broker_health`
- Makefile: `make pact-up`, `pact-down`, `pact-logs`

### F26 — Toxiproxy Network Chaos (#175-#180)
- **F26.01** Docker Compose profile `toxiproxy` (:8474 + range 8475-8485)
- **F26.02-03** `ChaosNetworkService` wrapping Toxiproxy REST API
- **F26.04** 4 presets: `latency`, `bandwidth`, `packet-loss`, `slow-close`
- **F26.05** Makefile: `toxiproxy-up`, `toxiproxy-down`, `toxiproxy-logs`
- **F26.06** 5 MCP tools: `network_list_proxies`, `network_create_proxy`, `network_apply_preset`, `network_list_presets`, `network_toxiproxy_health`