### PR TITLE
✨ feat(cli): F17 + F30 — @stubrix/cli package & Taskfile automation (v1.9.0)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+includes:
+  mock: ./taskfiles/mock.yml
+  db: ./taskfiles/db.yml
+  chaos: ./taskfiles/chaos.yml
+  scenario: ./taskfiles/scenario.yml
+  ai: ./taskfiles/ai.yml
+  infra: ./taskfiles/infra.yml
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+  MOCK_PORT: '{{.MOCK_PORT | default "8081"}}'
+
+tasks:
+  default:
+    desc: Show available tasks
+    cmds:
+      - task --list
+
+  up:
+    desc: Start WireMock + API (default engine)
+    cmds:
+      - docker compose --profile wiremock up -d
+
+  down:
+    desc: Stop all Stubrix services
+    cmds:
+      - docker compose --profile wiremock --profile mockoon --profile postgres --profile mysql down
+
+  status:
+    desc: Show API status
+    cmds:
+      - curl -s {{.API_URL}}/api/status | jq .
+
+  doctor:
+    desc: Health check all Stubrix services
+    cmds:
+      - echo "=== API ===" && curl -sf {{.API_URL}}/api/status > /dev/null && echo "✅ API OK" || echo "❌ API unreachable"
+      - echo "=== Intelligence ===" && curl -sf {{.API_URL}}/api/intelligence/health | jq -r '"✅ RAG: \(.available)"' 2>/dev/null || echo "⚠️  RAG offline"
+      - echo "=== Pact Broker ===" && curl -sf {{.API_URL}}/api/contracts/health | jq -r '"✅ Pact: \(.available)"' 2>/dev/null || echo "⚠️  Pact offline"
+      - echo "=== Toxiproxy ===" && curl -sf {{.API_URL}}/api/chaos-network/health | jq -r '"✅ Toxiproxy: \(.available)"' 2>/dev/null || echo "⚠️  Toxiproxy offline"
+
+  build:
+    desc: Build all packages
+    cmds:
+      - npm run build
+
+  clean:
+    desc: Stop all containers and clean volumes
+    cmds:
+      - docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy down -v 2>/dev/null || true
+      - rm -f .mockoon-env.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/api",
         "packages/ui",
         "packages/db-ui",
-        "packages/mock-ui"
+        "packages/mock-ui",
+        "packages/cli"
       ],
       "devDependencies": {
         "@usebruno/cli": "^1.4.0"
@@ -3059,7 +3060,6 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6258,6 +6258,10 @@
       "resolved": "packages/api",
       "link": true
     },
+    "node_modules/@stubrix/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@stubrix/db-ui": {
       "resolved": "packages/db-ui",
       "link": true
@@ -6579,6 +6583,15 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
@@ -6703,6 +6716,12 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7878,7 +7897,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -7894,7 +7912,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7904,7 +7921,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8885,7 +8901,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8914,7 +8929,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -8994,7 +9008,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9007,7 +9020,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -9277,6 +9289,15 @@
       "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -9733,7 +9754,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -10517,6 +10537,38 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10677,6 +10729,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10905,6 +10980,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -11079,6 +11166,18 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-func-name": {
@@ -11659,6 +11758,244 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/inquirer": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.2.2.tgz",
+      "integrity": "sha512-tyao/4Vo36XnUItZ7DnUXX4f1jVao2mSrleV/5IPtW/XAEA26hRVsbc68nuTEKWcr5vMP/1mVoT2O7u8H4v1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/prompts": "^5.5.0",
+        "@inquirer/type": "^1.5.3",
+        "@types/mute-stream": "^0.0.4",
+        "ansi-escapes": "^4.3.2",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/checkbox": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
+      "integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/confirm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
+      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/core/node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
+      "integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/expand": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
+      "integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/input": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
+      "integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/password": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
+      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/prompts": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
+      "integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.5.0",
+        "@inquirer/confirm": "^3.2.0",
+        "@inquirer/editor": "^2.2.0",
+        "@inquirer/expand": "^2.3.0",
+        "@inquirer/input": "^2.3.0",
+        "@inquirer/number": "^1.1.0",
+        "@inquirer/password": "^2.2.0",
+        "@inquirer/rawlist": "^2.3.0",
+        "@inquirer/search": "^1.1.0",
+        "@inquirer/select": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/rawlist": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
+      "integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/select": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
+      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/type": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -11869,7 +12206,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13549,6 +13885,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -13850,6 +14198,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -14092,6 +14460,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -15442,6 +15819,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15808,7 +16194,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -16128,6 +16513,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -16176,7 +16573,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16263,7 +16659,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16900,6 +17295,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -17235,7 +17642,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -17766,6 +18172,15 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -18141,7 +18556,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18336,7 +18750,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -18432,6 +18845,238 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      }
+    },
+    "packages/cli": {
+      "name": "@stubrix/cli",
+      "version": "1.3.1",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0",
+        "inquirer": "^10.2.2",
+        "node-fetch": "^3.3.2",
+        "ora": "^8.1.1"
+      },
+      "bin": {
+        "stubrix": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cli/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/cli/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/db-ui": {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,16 @@
     "packages/api",
     "packages/ui",
     "packages/db-ui",
-    "packages/mock-ui"
+    "packages/mock-ui",
+    "packages/cli"
   ],
   "devDependencies": {
     "@usebruno/cli": "^1.4.0"
   },
   "scripts": {
     "bruno-test": "bash scripts/bruno-test.sh",
-    "build": "npm run build:shared && npm run build:api && npm run build:db-ui && npm run build:mock-ui && npm run build:ui",
+    "build": "npm run build:shared && npm run build:api && npm run build:db-ui && npm run build:mock-ui && npm run build:ui && npm run build:cli",
+    "build:cli": "npm run build -w @stubrix/cli",
     "build:shared": "npm run build -w @stubrix/shared",
     "build:api": "npm run build -w @stubrix/api",
     "build:db-ui": "npm run build -w @stubrix/db-ui",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,57 @@
+# @stubrix/cli
+
+Stubrix CLI — control your mock server platform from the terminal.
+
+## Installation
+
+```bash
+npm install -g @stubrix/cli
+# or from the monorepo
+npm run build -w @stubrix/cli
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `stubrix init` | Initialize a new Stubrix project |
+| `stubrix up` | Start mock engine (WireMock by default) |
+| `stubrix down` | Stop all services |
+| `stubrix status` | Show API status |
+| `stubrix doctor` | Health check all services |
+| `stubrix mock list` | List projects |
+| `stubrix mock create <projectId>` | Create a mock |
+| `stubrix mock import <file>` | Import HAR/Postman/OpenAPI |
+| `stubrix db engines` | List DB engines |
+| `stubrix db snapshot <engine>` | Create DB snapshot |
+| `stubrix db restore <engine> <name>` | Restore snapshot |
+| `stubrix chaos list` | List chaos profiles |
+| `stubrix chaos presets` | List built-in presets |
+| `stubrix chaos apply <preset>` | Apply chaos preset |
+| `stubrix scenario list` | List scenarios |
+| `stubrix scenario save <name>` | Capture current state |
+| `stubrix scenario restore <id>` | Restore a scenario |
+| `stubrix scenario diff <idA> <idB>` | Compare scenarios |
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STUBRIX_API_URL` | `http://localhost:9090` | API base URL |
+
+## Examples
+
+```bash
+# Start WireMock + PostgreSQL
+stubrix up --engine wiremock --postgres
+
+# Import a Postman collection
+stubrix mock import ./postman-collection.json
+
+# Apply slow network chaos
+stubrix chaos apply slow-network --url '/api/.*'
+
+# Capture and restore scenarios
+stubrix scenario save before-migration
+stubrix scenario restore <uuid>
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@stubrix/cli",
+  "version": "1.3.1",
+  "description": "Stubrix CLI — control plane from the terminal",
+  "bin": {
+    "stubrix": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "chalk": "^5.3.0",
+    "ora": "^8.1.1",
+    "inquirer": "^10.2.2",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "ts-node": "^10.9.2"
+  },
+  "files": ["dist/"],
+  "engines": { "node": ">=18" }
+}

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -1,0 +1,23 @@
+const BASE_URL = process.env.STUBRIX_API_URL ?? 'http://localhost:9090';
+
+export async function apiGet(path: string): Promise<unknown> {
+  const res = await fetch(`${BASE_URL}${path}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function apiPost(path: string, body?: unknown): Promise<unknown> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  const text = await res.text();
+  return text ? JSON.parse(text) : {};
+}
+
+export async function apiDelete(path: string): Promise<void> {
+  const res = await fetch(`${BASE_URL}${path}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+}

--- a/packages/cli/src/commands/chaos.ts
+++ b/packages/cli/src/commands/chaos.ts
@@ -1,0 +1,42 @@
+import { Command } from 'commander';
+import { apiGet, apiPost } from './api';
+
+export function registerChaosCommands(program: Command): void {
+  const chaos = program.command('chaos').description('Chaos engineering and fault injection');
+
+  chaos
+    .command('list')
+    .description('List chaos fault profiles')
+    .action(async () => {
+      const data = await apiGet('/api/chaos/profiles');
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  chaos
+    .command('presets')
+    .description('List built-in chaos presets')
+    .action(async () => {
+      const data = await apiGet('/api/chaos/presets');
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  chaos
+    .command('apply <preset>')
+    .description('Apply a built-in chaos preset (slow-network | flaky-service | total-outage | timeout)')
+    .option('--url <pattern>', 'URL regex filter')
+    .action(async (preset: string, opts: { url?: string }) => {
+      const result = await apiPost('/api/chaos/presets/apply', {
+        preset,
+        urlPattern: opts.url,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  chaos
+    .command('disable <id>')
+    .description('Disable a chaos profile by ID')
+    .action(async (id: string) => {
+      const result = await apiPost(`/api/chaos/profiles/${id}/toggle`, { enabled: false });
+      console.log(JSON.stringify(result, null, 2));
+    });
+}

--- a/packages/cli/src/commands/databases.ts
+++ b/packages/cli/src/commands/databases.ts
@@ -1,0 +1,39 @@
+import { Command } from 'commander';
+import { apiGet, apiPost } from './api';
+
+export function registerDatabaseCommands(program: Command): void {
+  const db = program.command('db').description('Database snapshot management');
+
+  db
+    .command('engines')
+    .description('List available database engines')
+    .action(async () => {
+      const data = await apiGet('/api/db/engines');
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  db
+    .command('snapshots <engine>')
+    .description('List snapshots for a database engine')
+    .action(async (engine: string) => {
+      const data = await apiGet(`/api/db/${engine}/snapshots`);
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  db
+    .command('snapshot <engine>')
+    .description('Create a database snapshot')
+    .option('--name <name>', 'Snapshot name')
+    .action(async (engine: string, opts: { name?: string }) => {
+      const result = await apiPost(`/api/db/${engine}/snapshots`, { name: opts.name });
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  db
+    .command('restore <engine> <snapshotName>')
+    .description('Restore a database snapshot')
+    .action(async (engine: string, snapshotName: string) => {
+      const result = await apiPost(`/api/db/${engine}/snapshots/${snapshotName}/restore`, {});
+      console.log(JSON.stringify(result, null, 2));
+    });
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander';
+import { apiGet } from './api';
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Check Stubrix environment health (API, WireMock, RAG, Pact)')
+    .action(async () => {
+      const checks: Array<{ name: string; url: string }> = [
+        { name: 'API', url: '/api/status' },
+        { name: 'Intelligence (RAG)', url: '/api/intelligence/health' },
+        { name: 'Pact Broker', url: '/api/contracts/health' },
+        { name: 'Toxiproxy', url: '/api/chaos-network/health' },
+      ];
+
+      let allOk = true;
+      for (const check of checks) {
+        try {
+          const data = (await apiGet(check.url)) as Record<string, unknown>;
+          const ok = data['available'] !== false && data['status'] !== 'error';
+          console.log(`  ${ok ? '✅' : '⚠️ '} ${check.name}`);
+          if (!ok) allOk = false;
+        } catch {
+          console.log(`  ❌ ${check.name} (unreachable)`);
+          allOk = false;
+        }
+      }
+      if (!allOk) process.exit(1);
+    });
+}

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import { execSync } from 'child_process';
+
+export function registerDownCommand(program: Command): void {
+  program
+    .command('down')
+    .description('Stop all Stubrix services')
+    .option('--volumes', 'Also remove volumes')
+    .action((opts: { volumes?: boolean }) => {
+      const flag = opts.volumes ? '-v' : '';
+      console.log('Stopping Stubrix services...');
+      execSync(
+        `docker compose --profile wiremock --profile mockoon --profile postgres --profile mysql down ${flag}`,
+        { stdio: 'inherit' },
+      );
+    });
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function registerInitCommand(program: Command): void {
+  program
+    .command('init')
+    .description('Initialize a new Stubrix project in the current directory')
+    .option('-n, --name <name>', 'Project name', 'my-stubrix')
+    .action((opts: { name: string }) => {
+      const dirs = ['mocks/mappings', 'mocks/__files'];
+      for (const d of dirs) {
+        fs.mkdirSync(path.join(process.cwd(), d), { recursive: true });
+        console.log(`  created ${d}`);
+      }
+
+      const envFile = path.join(process.cwd(), '.env');
+      if (!fs.existsSync(envFile)) {
+        fs.writeFileSync(envFile, `STUBRIX_PROJECT=${opts.name}\nMOCK_PORT=8081\nAPI_PORT=9090\n`);
+        console.log('  created .env');
+      }
+
+      console.log(`\nStubrix project "${opts.name}" initialized.`);
+      console.log('Run: make wiremock   or   docker compose --profile wiremock up -d');
+    });
+}

--- a/packages/cli/src/commands/mocks.ts
+++ b/packages/cli/src/commands/mocks.ts
@@ -1,0 +1,59 @@
+import { Command } from 'commander';
+import { apiGet, apiPost, apiDelete } from './api';
+
+export function registerMockCommands(program: Command): void {
+  const mocks = program.command('mock').description('Mock management');
+
+  mocks
+    .command('list [projectId]')
+    .description('List mocks (optionally filtered by project)')
+    .option('--json', 'Output raw JSON')
+    .action(async (projectId: string | undefined, opts: { json?: boolean }) => {
+      const url = projectId ? `/api/projects/${projectId}/mocks` : '/api/projects';
+      const data = await apiGet(url);
+      if (opts.json) {
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        const items = Array.isArray(data) ? data : [data];
+        for (const item of items) {
+          const m = item as Record<string, unknown>;
+          console.log(`  ${m['id'] ?? m['name'] ?? JSON.stringify(m)}`);
+        }
+      }
+    });
+
+  mocks
+    .command('create <projectId>')
+    .description('Create a mock in a project')
+    .requiredOption('--method <method>', 'HTTP method')
+    .requiredOption('--path <path>', 'URL path')
+    .option('--status <status>', 'Response status code', '200')
+    .option('--body <body>', 'Response body JSON', '{}')
+    .action(async (projectId: string, opts: { method: string; path: string; status: string; body: string }) => {
+      const result = await apiPost(`/api/projects/${projectId}/mocks`, {
+        request: { method: opts.method.toUpperCase(), urlPath: opts.path },
+        response: { status: parseInt(opts.status), body: opts.body, headers: { 'Content-Type': 'application/json' } },
+      });
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  mocks
+    .command('delete <projectId> <mockId>')
+    .description('Delete a mock')
+    .action(async (projectId: string, mockId: string) => {
+      await apiDelete(`/api/projects/${projectId}/mocks/${mockId}`);
+      console.log(`Mock ${mockId} deleted.`);
+    });
+
+  mocks
+    .command('import <file>')
+    .description('Import mocks from HAR/Postman/OpenAPI file')
+    .option('--preview', 'Preview without importing')
+    .action(async (file: string, opts: { preview?: boolean }) => {
+      const { readFileSync } = await import('fs');
+      const content = readFileSync(file, 'utf-8');
+      const url = opts.preview ? '/api/import/preview' : '/api/import/content';
+      const result = await apiPost(url, { content, filename: file });
+      console.log(JSON.stringify(result, null, 2));
+    });
+}

--- a/packages/cli/src/commands/scenarios.ts
+++ b/packages/cli/src/commands/scenarios.ts
@@ -1,0 +1,59 @@
+import { Command } from 'commander';
+import { apiGet, apiPost, apiDelete } from './api';
+
+export function registerScenarioCommands(program: Command): void {
+  const scenario = program.command('scenario').description('Time Machine scenario management');
+
+  scenario
+    .command('list')
+    .description('List all captured scenarios')
+    .action(async () => {
+      const data = await apiGet('/api/scenarios');
+      const items = Array.isArray(data) ? data : [];
+      if (items.length === 0) {
+        console.log('No scenarios found.');
+        return;
+      }
+      for (const s of items) {
+        const sc = s as Record<string, unknown>;
+        const meta = sc['meta'] ? (sc['meta'] as Record<string, unknown>) : sc;
+        console.log(`  ${meta['id']}  ${meta['name']}  (${meta['createdAt']})`);
+      }
+    });
+
+  scenario
+    .command('save <name>')
+    .description('Capture current environment state as a named scenario')
+    .option('--description <desc>', 'Optional description')
+    .action(async (name: string, opts: { description?: string }) => {
+      const result = await apiPost('/api/scenarios/capture', {
+        name,
+        description: opts.description,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  scenario
+    .command('restore <id>')
+    .description('Restore environment from a scenario')
+    .action(async (id: string) => {
+      const result = await apiPost(`/api/scenarios/${id}/restore`, {});
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  scenario
+    .command('diff <idA> <idB>')
+    .description('Compare two scenarios')
+    .action(async (idA: string, idB: string) => {
+      const result = await apiGet(`/api/scenarios/${idA}/diff/${idB}`);
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  scenario
+    .command('delete <id>')
+    .description('Delete a scenario')
+    .action(async (id: string) => {
+      await apiDelete(`/api/scenarios/${id}`);
+      console.log(`Scenario ${id} deleted.`);
+    });
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import { apiGet } from './api';
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command('status')
+    .description('Show Stubrix API status')
+    .action(async () => {
+      try {
+        const data = await apiGet('/api/status');
+        console.log(JSON.stringify(data, null, 2));
+      } catch (err) {
+        console.error(`API unavailable: ${(err as Error).message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import { execSync } from 'child_process';
+
+export function registerUpCommand(program: Command): void {
+  program
+    .command('up')
+    .description('Start Stubrix services (WireMock + API)')
+    .option('--engine <engine>', 'Mock engine: wiremock | mockoon', 'wiremock')
+    .option('--postgres', 'Also start PostgreSQL')
+    .action((opts: { engine: string; postgres?: boolean }) => {
+      const profiles = [opts.engine];
+      if (opts.postgres) profiles.push('postgres');
+      const profileFlags = profiles.map((p) => `--profile ${p}`).join(' ');
+      console.log(`Starting Stubrix (${profiles.join(', ')})...`);
+      execSync(`docker compose ${profileFlags} up -d`, { stdio: 'inherit' });
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { registerInitCommand } from './commands/init';
+import { registerUpCommand } from './commands/up';
+import { registerDownCommand } from './commands/down';
+import { registerStatusCommand } from './commands/status';
+import { registerDoctorCommand } from './commands/doctor';
+import { registerMockCommands } from './commands/mocks';
+import { registerDatabaseCommands } from './commands/databases';
+import { registerChaosCommands } from './commands/chaos';
+import { registerScenarioCommands } from './commands/scenarios';
+
+const program = new Command();
+
+program
+  .name('stubrix')
+  .description('Stubrix CLI — professional mock server control plane')
+  .version('1.3.1');
+
+registerInitCommand(program);
+registerUpCommand(program);
+registerDownCommand(program);
+registerStatusCommand(program);
+registerDoctorCommand(program);
+registerMockCommands(program);
+registerDatabaseCommands(program);
+registerChaosCommands(program);
+registerScenarioCommands(program);
+
+program.parse(process.argv);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/taskfiles/ai.yml
+++ b/taskfiles/ai.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+
+tasks:
+  up:
+    desc: Start ChromaDB + OpenRAG AI layer
+    cmds:
+      - docker compose --profile ai up -d
+
+  down:
+    desc: Stop AI/RAG services
+    cmds:
+      - docker compose --profile ai down
+
+  health:
+    desc: Check OpenRAG availability
+    cmds:
+      - curl -s {{.API_URL}}/api/intelligence/health | jq .
+
+  query:
+    desc: Ask a question to RAG (Q="your question")
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/intelligence/query \
+          -H 'Content-Type: application/json' \
+          -d '{"question":"{{.Q}}"}' | jq .
+
+  suggest-mock:
+    desc: Generate a mock from natural language (DESC="GET /users returns users")
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/intelligence/suggest/mock \
+          -H 'Content-Type: application/json' \
+          -d '{"description":"{{.DESC}}"}' | jq .
+
+  index:
+    desc: Index all mocks into the RAG vector store
+    cmds:
+      - curl -s -X POST {{.API_URL}}/api/intelligence/index | jq .

--- a/taskfiles/chaos.yml
+++ b/taskfiles/chaos.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+
+tasks:
+  list:
+    desc: List chaos fault profiles
+    cmds:
+      - curl -s {{.API_URL}}/api/chaos/profiles | jq .
+
+  presets:
+    desc: List built-in chaos presets
+    cmds:
+      - curl -s {{.API_URL}}/api/chaos/presets | jq .
+
+  apply:
+    desc: Apply a chaos preset (PRESET=slow-network URL=<regex>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/chaos/presets/apply \
+          -H 'Content-Type: application/json' \
+          -d '{"preset":"{{.PRESET | default "slow-network"}}","urlPattern":"{{.URL}}"}' | jq .
+
+  disable:
+    desc: Disable a chaos profile (ID=<uuid>)
+    cmds:
+      - |
+        curl -s -X PATCH {{.API_URL}}/api/chaos/profiles/{{.ID}}/toggle \
+          -H 'Content-Type: application/json' \
+          -d '{"enabled":false}' | jq .
+
+  network-up:
+    desc: Start Toxiproxy
+    cmds:
+      - docker compose --profile toxiproxy up -d
+
+  network-down:
+    desc: Stop Toxiproxy
+    cmds:
+      - docker compose --profile toxiproxy down

--- a/taskfiles/db.yml
+++ b/taskfiles/db.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+
+tasks:
+  engines:
+    desc: List available database engines
+    cmds:
+      - curl -s {{.API_URL}}/api/db/engines | jq .
+
+  snapshots:
+    desc: List snapshots for an engine (ENGINE=postgres)
+    cmds:
+      - curl -s {{.API_URL}}/api/db/{{.ENGINE | default "postgres"}}/snapshots | jq .
+
+  snapshot:
+    desc: Create a snapshot (ENGINE=postgres NAME=my-snapshot)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/db/{{.ENGINE | default "postgres"}}/snapshots \
+          -H 'Content-Type: application/json' \
+          -d '{"name":"{{.NAME | default "snapshot"}}"}' | jq .
+
+  restore:
+    desc: Restore a snapshot (ENGINE=postgres SNAPSHOT=<name>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/db/{{.ENGINE | default "postgres"}}/snapshots/{{.SNAPSHOT}}/restore \
+          -H 'Content-Type: application/json' \
+          -d '{}' | jq .

--- a/taskfiles/infra.yml
+++ b/taskfiles/infra.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+tasks:
+  postgres-up:
+    desc: Start PostgreSQL
+    cmds:
+      - docker compose --profile postgres up -d
+
+  mysql-up:
+    desc: Start MySQL
+    cmds:
+      - docker compose --profile mysql up -d
+
+  adminer-up:
+    desc: Start Adminer DB viewer
+    cmds:
+      - docker compose --profile postgres --profile adminer up -d
+
+  cloudbeaver-up:
+    desc: Start CloudBeaver DB IDE
+    cmds:
+      - docker compose --profile postgres --profile cloudbeaver up -d
+
+  pact-up:
+    desc: Start Pact Broker
+    cmds:
+      - docker compose --profile postgres --profile pact up -d
+
+  pact-down:
+    desc: Stop Pact Broker
+    cmds:
+      - docker compose --profile pact down
+
+  hoppscotch-up:
+    desc: Start Hoppscotch API client
+    cmds:
+      - docker compose --profile hoppscotch up -d
+
+  hoppscotch-down:
+    desc: Stop Hoppscotch
+    cmds:
+      - docker compose --profile hoppscotch down

--- a/taskfiles/mock.yml
+++ b/taskfiles/mock.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+
+tasks:
+  list:
+    desc: List all projects
+    cmds:
+      - curl -s {{.API_URL}}/api/projects | jq .
+
+  create:
+    desc: Create a mock (PROJECT=<id> METHOD=GET PATH=/foo STATUS=200 BODY='{}')
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/projects/{{.PROJECT}}/mocks \
+          -H 'Content-Type: application/json' \
+          -d '{"request":{"method":"{{.METHOD | default "GET"}}","urlPath":"{{.PATH | default "/example"}}"},"response":{"status":{{.STATUS | default 200}},"body":{{.BODY | default "{}"}}}}' | jq .
+
+  import:
+    desc: Import mocks from file (FILE=<path>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/import/content \
+          -H 'Content-Type: application/json' \
+          -d "{\"content\":$(cat {{.FILE}} | jq -Rs .)}" | jq .
+
+  lint:
+    desc: Lint an OpenAPI spec (FILE=<path>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/governance/lint \
+          -H 'Content-Type: application/json' \
+          -d "{\"content\":$(cat {{.FILE}} | jq -Rs .)}" | jq .
+
+  coverage:
+    desc: Run mock coverage report (FILE=<openapi-spec>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/coverage/analyze \
+          -H 'Content-Type: application/json' \
+          -d "{\"content\":$(cat {{.FILE}} | jq -Rs .)}" | jq .

--- a/taskfiles/scenario.yml
+++ b/taskfiles/scenario.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+vars:
+  API_URL: '{{.API_URL | default "http://localhost:9090"}}'
+
+tasks:
+  list:
+    desc: List all captured scenarios
+    cmds:
+      - curl -s {{.API_URL}}/api/scenarios | jq .
+
+  save:
+    desc: Capture current state as scenario (NAME=<name>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/scenarios/capture \
+          -H 'Content-Type: application/json' \
+          -d '{"name":"{{.NAME | default "snapshot"}}"}' | jq .
+
+  restore:
+    desc: Restore a scenario (ID=<uuid>)
+    cmds:
+      - |
+        curl -s -X POST {{.API_URL}}/api/scenarios/{{.ID}}/restore | jq .
+
+  diff:
+    desc: Compare two scenarios (A=<uuid> B=<uuid>)
+    cmds:
+      - curl -s {{.API_URL}}/api/scenarios/{{.A}}/diff/{{.B}} | jq .
+
+  delete:
+    desc: Delete a scenario (ID=<uuid>)
+    cmds:
+      - curl -s -X DELETE {{.API_URL}}/api/scenarios/{{.ID}}


### PR DESCRIPTION
## 📝 Descrição

Implementação completa do milestone **v1.9.0 — CLI & Automation** cobrindo 2 épicos.

## 🔗 Issues Relacionadas

Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
Closes #124
Closes #125
Closes #194
Closes #195
Closes #196
Closes #197
Closes #198
Closes #39
Closes #52

## 🎯 O que foi implementado

### F17 — @stubrix/cli (#119-#125)
- **F17.01** `packages/cli/` — novo pacote npm `@stubrix/cli` com Commander.js
- **F17.02** Comandos core: `init`, `up`, `down`, `status`, `doctor`
- **F17.03** Submenu `mock`: `list`, `create`, `delete`, `import`
- **F17.04** Submenu `db`: `engines`, `snapshots`, `snapshot`, `restore`
- **F17.05** Submenu `chaos` e `scenario` com todos os comandos CRUD
- **F17.06** Helper `api.ts` com `apiGet/apiPost/apiDelete` respeitando `STUBRIX_API_URL`
- **F17.07** Output JSON via `--json` flag para modo CI/CD

### F30 — Taskfile (#194-#198)
- **F30.01** `Taskfile.yml` root com 6 includes e tasks: `up`, `down`, `status`, `doctor`, `build`, `clean`
- **F30.02** Sub-Taskfiles: `mock.yml`, `db.yml`, `chaos.yml`, `scenario.yml`, `ai.yml`, `infra.yml`
- **F30.03** Cobre toda a funcionalidade do Makefile em forma namespada (`task mock:list`, `task db:snapshot`, etc.)
- **F30.04** `packages/cli/README.md` com referência completa de comandos e exemplos
- Adicionado `packages/cli` ao npm workspaces e script `build:cli`