### PR TITLE
✨ feat(api): F15 + F16 + F25 — GraphQL/gRPC, Events, Webhooks (v2.0.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,25 @@ SQLITE_DB_PATH=
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
 
+# Kafka / Redpanda – Event-driven mocking (F16.01)
+KAFKA_PORT=9092
+KAFKA_REST_PORT=8082
+KAFKA_REST_URL=http://localhost:8082
+KAFKA_CONSOLE_PORT=8080
+
+# RabbitMQ – AMQP broker (F16.02)
+RABBITMQ_PORT=5672
+RABBITMQ_MANAGEMENT_PORT=15672
+RABBITMQ_API_URL=http://localhost:15672
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+RABBITMQ_VHOST=%2F
+
+# GripMock – gRPC mock engine (F15.06)
+GRIPMOCK_PORT=4770
+GRIPMOCK_API_PORT=4771
+GRIPMOCK_URL=http://localhost:4771
+
 # Pact Broker – Contract Testing (F13.01)
 PACT_BROKER_URL=http://localhost:9292
 PACT_BROKER_PORT=9292

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@
         ai-up ai-down ai-logs \
         scenario-save scenario-restore scenario-list \
         pact-up pact-down pact-logs \
-        toxiproxy-up toxiproxy-down toxiproxy-logs
+        toxiproxy-up toxiproxy-down toxiproxy-logs \
+        kafka-up kafka-down kafka-logs \
+        rabbitmq-up rabbitmq-down rabbitmq-logs \
+        gripmock-up gripmock-down
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -156,6 +159,30 @@ toxiproxy-down: ## Stop Toxiproxy
 toxiproxy-logs: ## Tail Toxiproxy logs
 	docker compose --profile toxiproxy logs -f toxiproxy
 
+kafka-up: ## Start Redpanda (Kafka) + console (F16.01 — detached)
+	docker compose --profile kafka up -d
+
+kafka-down: ## Stop Redpanda/Kafka
+	docker compose --profile kafka down
+
+kafka-logs: ## Tail Redpanda logs
+	docker compose --profile kafka logs -f redpanda
+
+rabbitmq-up: ## Start RabbitMQ (F16.02 — detached)
+	docker compose --profile rabbitmq up -d
+
+rabbitmq-down: ## Stop RabbitMQ
+	docker compose --profile rabbitmq down
+
+rabbitmq-logs: ## Tail RabbitMQ logs
+	docker compose --profile rabbitmq logs -f rabbitmq
+
+gripmock-up: ## Start GripMock gRPC mock engine (F15.06 — detached)
+	docker compose --profile gripmock up -d
+
+gripmock-down: ## Stop GripMock
+	docker compose --profile gripmock down
+
 hoppscotch: ## Start Hoppscotch self-hosted API client (F8.01 — http://localhost:3100)
 	docker compose --profile hoppscotch up
 
@@ -174,7 +201,7 @@ bruno-test-collection: ## Run Bruno tests for a specific collection (e.g. make b
 	COLLECTION=$(COLLECTION) bash scripts/bruno-test.sh
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -198,7 +225,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@
 ## Contracts (F13):
 ##   docker compose --profile pact up -d               # Pact Broker → http://localhost:9292
 ##
+## Events (F16):
+##   docker compose --profile kafka up -d               # Redpanda (Kafka) → :9092 / :8082
+##   docker compose --profile rabbitmq up -d            # RabbitMQ → :5672 / :15672
+##
+## gRPC (F15):
+##   docker compose --profile gripmock up -d            # GripMock → :4770 / :4771
+##
 ## Network Chaos (F26):
 ##   docker compose --profile toxiproxy up -d          # Toxiproxy → http://localhost:8474
 ##
@@ -187,6 +194,71 @@ services:
     volumes:
       - cloudbeaver_data:/opt/cloudbeaver/workspace
       - ./config/cloudbeaver:/opt/cloudbeaver/conf:ro
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Redpanda – Kafka-compatible broker for event-driven mocking (F16.01)
+  # Kafka: localhost:9092 | REST: http://localhost:8082 | Console: http://localhost:8080
+  # --------------------------------------------------------------------------
+  redpanda:
+    image: redpandadata/redpanda:latest
+    profiles: ["kafka", "events"]
+    container_name: stubrix-redpanda
+    command:
+      - redpanda
+      - start
+      - --smp 1
+      - --memory 512M
+      - --kafka-addr PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr PLAINTEXT://localhost:9092
+      - --pandaproxy-addr 0.0.0.0:8082
+      - --advertise-pandaproxy-addr localhost:8082
+    ports:
+      - "${KAFKA_PORT:-9092}:9092"
+      - "${KAFKA_REST_PORT:-8082}:8082"
+    restart: unless-stopped
+
+  redpanda-console:
+    image: redpandadata/console:latest
+    profiles: ["kafka", "events"]
+    container_name: stubrix-redpanda-console
+    ports:
+      - "${KAFKA_CONSOLE_PORT:-8080}:8080"
+    environment:
+      KAFKA_BROKERS: redpanda:9092
+    depends_on:
+      - redpanda
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # RabbitMQ – AMQP message broker (F16.02)
+  # AMQP: localhost:5672 | Management: http://localhost:15672 (guest/guest)
+  # --------------------------------------------------------------------------
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    profiles: ["rabbitmq", "events"]
+    container_name: stubrix-rabbitmq
+    ports:
+      - "${RABBITMQ_PORT:-5672}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # GripMock – gRPC mock engine (F15.06)
+  # gRPC: localhost:4770 | Stub API: http://localhost:4771
+  # --------------------------------------------------------------------------
+  gripmock:
+    image: tkpd/gripmock:latest
+    profiles: ["gripmock", "grpc"]
+    container_name: stubrix-gripmock
+    ports:
+      - "${GRIPMOCK_PORT:-4770}:4770"
+      - "${GRIPMOCK_API_PORT:-4771}:4771"
+    volumes:
+      - ./mocks/proto:/proto:ro
     restart: unless-stopped
 
   # --------------------------------------------------------------------------

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -19,6 +19,9 @@ import { IntelligenceModule } from './intelligence/intelligence.module';
 import { ChaosModule } from './chaos/chaos.module';
 import { ContractsModule } from './contracts/contracts.module';
 import { ChaosNetworkModule } from './chaos-network/chaos-network.module';
+import { WebhooksModule } from './webhooks/webhooks.module';
+import { EventsModule } from './events/events.module';
+import { ProtocolsModule } from './protocols/protocols.module';
 
 export function setupSwagger(app: any) {
   const config = new DocumentBuilder()
@@ -40,6 +43,9 @@ export function setupSwagger(app: any) {
     .addTag('chaos', 'Fault injection and chaos engineering')
     .addTag('contracts', 'Pact Broker contract testing')
     .addTag('chaos-network', 'Toxiproxy network-level chaos')
+    .addTag('webhooks', 'Webhook receiver, replay and simulator')
+    .addTag('events', 'Event publishing — Kafka & RabbitMQ')
+    .addTag('protocols', 'Multi-protocol mocks — GraphQL & gRPC')
     .addTag('status', 'System status')
     .addServer('http://localhost:9090', 'Development server')
     .addServer('https://api.stubrix.com', 'Production server')
@@ -90,6 +96,9 @@ export function setupSwagger(app: any) {
     ChaosModule,
     ContractsModule,
     ChaosNetworkModule,
+    WebhooksModule,
+    EventsModule,
+    ProtocolsModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/events/events.controller.ts
+++ b/packages/api/src/events/events.controller.ts
@@ -1,0 +1,93 @@
+import { Controller, Get, Post, Param, Body, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { IsString, IsOptional, IsNumber, IsObject } from 'class-validator';
+import { EventsService } from './events.service';
+import type { BrokerType } from './events.service';
+
+export class PublishEventDto {
+  @IsString()
+  broker: BrokerType;
+
+  @IsString()
+  topic: string;
+
+  payload: unknown;
+
+  @IsOptional()
+  @IsObject()
+  headers?: Record<string, string>;
+}
+
+export class CreateTemplateDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  broker: BrokerType;
+
+  @IsString()
+  topic: string;
+
+  payload: unknown;
+
+  @IsOptional()
+  @IsObject()
+  headers?: Record<string, string>;
+
+  @IsOptional()
+  @IsNumber()
+  scheduleMs?: number;
+}
+
+@ApiTags('events')
+@Controller('api/events')
+export class EventsController {
+  constructor(private readonly service: EventsService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check Kafka and RabbitMQ availability' })
+  health() {
+    return this.service.healthCheck();
+  }
+
+  @Post('publish')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Publish an event to Kafka or RabbitMQ' })
+  publish(@Body() dto: PublishEventDto) {
+    return this.service.publish(dto.broker, dto.topic, dto.payload, dto.headers);
+  }
+
+  @Get('published')
+  @ApiOperation({ summary: 'List recently published events' })
+  @ApiQuery({ name: 'limit', required: false })
+  listPublished(@Query('limit') limit?: string) {
+    return this.service.listPublished(limit ? parseInt(limit) : 50);
+  }
+
+  @Get('templates')
+  @ApiOperation({ summary: 'List event templates' })
+  listTemplates() {
+    return this.service.listTemplates();
+  }
+
+  @Post('templates')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create an event template' })
+  createTemplate(@Body() dto: CreateTemplateDto) {
+    return this.service.createTemplate(
+      dto.name,
+      dto.broker,
+      dto.topic,
+      dto.payload,
+      dto.headers,
+      dto.scheduleMs,
+    );
+  }
+
+  @Post('templates/:id/fire')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Fire an event template' })
+  fire(@Param('id') id: string) {
+    return this.service.fireTemplate(id);
+  }
+}

--- a/packages/api/src/events/events.module.ts
+++ b/packages/api/src/events/events.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+
+@Module({
+  controllers: [EventsController],
+  providers: [EventsService],
+  exports: [EventsService],
+})
+export class EventsModule {}

--- a/packages/api/src/events/events.service.ts
+++ b/packages/api/src/events/events.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+export type BrokerType = 'kafka' | 'rabbitmq';
+
+export interface EventTemplate {
+  id: string;
+  name: string;
+  broker: BrokerType;
+  topic: string;
+  payload: unknown;
+  headers?: Record<string, string>;
+  scheduleMs?: number;
+  createdAt: string;
+}
+
+export interface PublishedEvent {
+  id: string;
+  templateId?: string;
+  broker: BrokerType;
+  topic: string;
+  payload: unknown;
+  publishedAt: string;
+  status: 'ok' | 'error';
+  error?: string;
+}
+
+@Injectable()
+export class EventsService {
+  private readonly logger = new Logger(EventsService.name);
+  private readonly kafkaUrl: string;
+  private readonly rabbitmqUrl: string;
+  private readonly storageDir: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.kafkaUrl = this.config.get<string>('KAFKA_REST_URL') ?? 'http://localhost:8082';
+    this.rabbitmqUrl = this.config.get<string>('RABBITMQ_API_URL') ?? 'http://localhost:15672';
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.storageDir = path.join(mocksDir, 'events');
+    fs.mkdirSync(this.storageDir, { recursive: true });
+  }
+
+  async publish(broker: BrokerType, topic: string, payload: unknown, headers?: Record<string, string>): Promise<PublishedEvent> {
+    const event: PublishedEvent = {
+      id: uuidv4(),
+      broker,
+      topic,
+      payload,
+      publishedAt: new Date().toISOString(),
+      status: 'ok',
+    };
+
+    try {
+      if (broker === 'kafka') {
+        await this.publishKafka(topic, payload, headers);
+      } else {
+        await this.publishRabbitMQ(topic, payload, headers);
+      }
+    } catch (err) {
+      event.status = 'error';
+      event.error = (err as Error).message;
+      this.logger.warn(`Event publish failed (${broker}/${topic}): ${event.error}`);
+    }
+
+    this.storeEvent(event);
+    return event;
+  }
+
+  listTemplates(): EventTemplate[] {
+    const file = path.join(this.storageDir, 'templates.json');
+    if (!fs.existsSync(file)) return [];
+    try {
+      return JSON.parse(fs.readFileSync(file, 'utf-8')) as EventTemplate[];
+    } catch { return []; }
+  }
+
+  createTemplate(
+    name: string,
+    broker: BrokerType,
+    topic: string,
+    payload: unknown,
+    headers?: Record<string, string>,
+    scheduleMs?: number,
+  ): EventTemplate {
+    const template: EventTemplate = {
+      id: uuidv4(),
+      name,
+      broker,
+      topic,
+      payload,
+      headers,
+      scheduleMs,
+      createdAt: new Date().toISOString(),
+    };
+    const file = path.join(this.storageDir, 'templates.json');
+    const templates = this.listTemplates();
+    templates.push(template);
+    fs.writeFileSync(file, JSON.stringify(templates, null, 2));
+    return template;
+  }
+
+  async fireTemplate(id: string): Promise<PublishedEvent> {
+    const template = this.listTemplates().find((t) => t.id === id);
+    if (!template) throw new Error(`Template not found: ${id}`);
+    return this.publish(template.broker, template.topic, template.payload, template.headers);
+  }
+
+  listPublished(limit = 50): PublishedEvent[] {
+    const file = path.join(this.storageDir, 'published.json');
+    if (!fs.existsSync(file)) return [];
+    try {
+      return (JSON.parse(fs.readFileSync(file, 'utf-8')) as PublishedEvent[]).slice(0, limit);
+    } catch { return []; }
+  }
+
+  async healthCheck(): Promise<{ kafka: boolean; rabbitmq: boolean }> {
+    const [kafka, rabbitmq] = await Promise.all([
+      fetch(`${this.kafkaUrl}/topics`, { signal: AbortSignal.timeout(3_000) })
+        .then((r) => r.ok)
+        .catch(() => false),
+      fetch(`${this.rabbitmqUrl}/api/overview`, { signal: AbortSignal.timeout(3_000) })
+        .then((r) => r.ok)
+        .catch(() => false),
+    ]);
+    return { kafka, rabbitmq };
+  }
+
+  private async publishKafka(topic: string, payload: unknown, headers?: Record<string, string>): Promise<void> {
+    const res = await fetch(`${this.kafkaUrl}/topics/${topic}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/vnd.kafka.json.v2+json', ...headers },
+      body: JSON.stringify({ records: [{ value: payload }] }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`Kafka REST HTTP ${res.status}`);
+  }
+
+  private async publishRabbitMQ(exchange: string, payload: unknown, _headers?: Record<string, string>): Promise<void> {
+    const vhost = this.config.get<string>('RABBITMQ_VHOST') ?? '%2F';
+    const user = this.config.get<string>('RABBITMQ_USER') ?? 'guest';
+    const pass = this.config.get<string>('RABBITMQ_PASS') ?? 'guest';
+    const auth = Buffer.from(`${user}:${pass}`).toString('base64');
+
+    const res = await fetch(`${this.rabbitmqUrl}/api/exchanges/${vhost}/${exchange}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Basic ${auth}` },
+      body: JSON.stringify({
+        properties: {},
+        routing_key: exchange,
+        payload: JSON.stringify(payload),
+        payload_encoding: 'string',
+      }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`RabbitMQ API HTTP ${res.status}`);
+  }
+
+  private storeEvent(event: PublishedEvent): void {
+    const file = path.join(this.storageDir, 'published.json');
+    const events = this.listPublished(499);
+    events.unshift(event);
+    fs.writeFileSync(file, JSON.stringify(events, null, 2));
+  }
+}

--- a/packages/api/src/protocols/protocols.controller.ts
+++ b/packages/api/src/protocols/protocols.controller.ts
@@ -1,0 +1,85 @@
+import { Controller, Get, Post, Delete, Param, Body, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { IsString, IsOptional, IsObject } from 'class-validator';
+import { ProtocolsService } from './protocols.service';
+import type { ProtocolType } from './protocols.service';
+
+export class CreateProtocolMockDto {
+  @IsString()
+  protocol: ProtocolType;
+
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  schema?: string;
+
+  @IsOptional()
+  @IsObject()
+  resolvers?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsString()
+  protoFile?: string;
+
+  @IsOptional()
+  @IsString()
+  grpcService?: string;
+
+  @IsOptional()
+  @IsString()
+  endpoint?: string;
+}
+
+export class ParseSchemaDto {
+  @IsString()
+  schema: string;
+}
+
+@ApiTags('protocols')
+@Controller('api/protocols')
+export class ProtocolsController {
+  constructor(private readonly service: ProtocolsService) {}
+
+  @Get('mocks')
+  @ApiOperation({ summary: 'List protocol mocks (GraphQL, gRPC, REST)' })
+  @ApiQuery({ name: 'protocol', required: false })
+  list(@Query('protocol') protocol?: string) {
+    return this.service.listMocks(protocol as ProtocolType | undefined);
+  }
+
+  @Post('mocks')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a protocol mock' })
+  create(@Body() dto: CreateProtocolMockDto) {
+    return this.service.createMock(dto.protocol, dto.name, {
+      schema: dto.schema,
+      resolvers: dto.resolvers,
+      protoFile: dto.protoFile,
+      grpcService: dto.grpcService,
+      endpoint: dto.endpoint,
+    });
+  }
+
+  @Delete('mocks/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a protocol mock' })
+  @ApiParam({ name: 'id', description: 'Mock UUID' })
+  delete(@Param('id') id: string): void {
+    this.service.deleteMock(id);
+  }
+
+  @Post('graphql/parse')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Parse a GraphQL schema and return summary' })
+  parseSchema(@Body() dto: ParseSchemaDto) {
+    return this.service.parseGraphQLSchema(dto.schema);
+  }
+
+  @Get('grpc/health')
+  @ApiOperation({ summary: 'Check GripMock (gRPC mock engine) availability' })
+  grpcHealth() {
+    return this.service.gripMockHealth();
+  }
+}

--- a/packages/api/src/protocols/protocols.module.ts
+++ b/packages/api/src/protocols/protocols.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProtocolsController } from './protocols.controller';
+import { ProtocolsService } from './protocols.service';
+
+@Module({
+  controllers: [ProtocolsController],
+  providers: [ProtocolsService],
+  exports: [ProtocolsService],
+})
+export class ProtocolsModule {}

--- a/packages/api/src/protocols/protocols.service.ts
+++ b/packages/api/src/protocols/protocols.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+export type ProtocolType = 'graphql' | 'grpc' | 'rest';
+
+export interface ProtocolMock {
+  id: string;
+  protocol: ProtocolType;
+  name: string;
+  schema?: string;
+  resolvers?: Record<string, unknown>;
+  protoFile?: string;
+  grpcService?: string;
+  endpoint?: string;
+  createdAt: string;
+}
+
+export interface GraphQLSchemaSummary {
+  types: string[];
+  queries: string[];
+  mutations: string[];
+  subscriptions: string[];
+}
+
+@Injectable()
+export class ProtocolsService {
+  private readonly logger = new Logger(ProtocolsService.name);
+  private readonly storageDir: string;
+  private readonly gripMockUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.storageDir = path.join(mocksDir, 'protocols');
+    this.gripMockUrl = this.config.get<string>('GRIPMOCK_URL') ?? 'http://localhost:4771';
+    fs.mkdirSync(this.storageDir, { recursive: true });
+  }
+
+  listMocks(protocol?: ProtocolType): ProtocolMock[] {
+    return fs
+      .readdirSync(this.storageDir)
+      .filter((f) => f.endsWith('.json'))
+      .flatMap((f) => {
+        try {
+          return [JSON.parse(fs.readFileSync(path.join(this.storageDir, f), 'utf-8')) as ProtocolMock];
+        } catch { return []; }
+      })
+      .filter((m) => !protocol || m.protocol === protocol)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  createMock(
+    protocol: ProtocolType,
+    name: string,
+    options: {
+      schema?: string;
+      resolvers?: Record<string, unknown>;
+      protoFile?: string;
+      grpcService?: string;
+      endpoint?: string;
+    },
+  ): ProtocolMock {
+    const mock: ProtocolMock = {
+      id: uuidv4(),
+      protocol,
+      name,
+      ...options,
+      createdAt: new Date().toISOString(),
+    };
+    const filename = `${protocol}_${name.replace(/[^a-z0-9]/gi, '_')}_${mock.id}.json`;
+    fs.writeFileSync(path.join(this.storageDir, filename), JSON.stringify(mock, null, 2));
+    this.logger.log(`Protocol mock created: ${protocol}/${name}`);
+    return mock;
+  }
+
+  deleteMock(id: string): void {
+    const files = fs.readdirSync(this.storageDir).filter((f) => f.endsWith('.json'));
+    for (const f of files) {
+      try {
+        const m = JSON.parse(fs.readFileSync(path.join(this.storageDir, f), 'utf-8')) as ProtocolMock;
+        if (m.id === id) {
+          fs.unlinkSync(path.join(this.storageDir, f));
+          return;
+        }
+      } catch { /* skip */ }
+    }
+    throw new Error(`Mock not found: ${id}`);
+  }
+
+  parseGraphQLSchema(schema: string): GraphQLSchemaSummary {
+    const types: string[] = [];
+    const queries: string[] = [];
+    const mutations: string[] = [];
+    const subscriptions: string[] = [];
+
+    const typeRegex = /^type\s+(\w+)/gm;
+    let m: RegExpExecArray | null;
+    while ((m = typeRegex.exec(schema)) !== null) {
+      const typeName = m[1];
+      if (typeName === 'Query') {
+        const block = schema.slice(m.index).match(/\{([^}]+)\}/);
+        if (block) queries.push(...block[1].trim().split('\n').map((l) => l.trim().split('(')[0]).filter(Boolean));
+      } else if (typeName === 'Mutation') {
+        const block = schema.slice(m.index).match(/\{([^}]+)\}/);
+        if (block) mutations.push(...block[1].trim().split('\n').map((l) => l.trim().split('(')[0]).filter(Boolean));
+      } else if (typeName === 'Subscription') {
+        const block = schema.slice(m.index).match(/\{([^}]+)\}/);
+        if (block) subscriptions.push(...block[1].trim().split('\n').map((l) => l.trim().split('(')[0]).filter(Boolean));
+      } else {
+        types.push(typeName);
+      }
+    }
+
+    return { types, queries, mutations, subscriptions };
+  }
+
+  async gripMockHealth(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.gripMockUrl}/api/stubs`, { signal: AbortSignal.timeout(3_000) });
+      return { available: res.ok, url: this.gripMockUrl };
+    } catch {
+      return { available: false, url: this.gripMockUrl };
+    }
+  }
+}

--- a/packages/api/src/webhooks/webhooks.controller.ts
+++ b/packages/api/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,125 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Body,
+  Headers,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Req,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { IsString, IsOptional, IsNumber, IsObject } from 'class-validator';
+import { WebhooksService } from './webhooks.service';
+import type { WebhookEvent, WebhookSimulation } from './webhooks.service';
+import type { Request } from 'express';
+
+export class CreateSimulationDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  targetUrl: string;
+
+  @IsOptional()
+  @IsString()
+  method?: string;
+
+  @IsOptional()
+  @IsObject()
+  headers?: Record<string, string>;
+
+  payload?: unknown;
+
+  @IsOptional()
+  @IsNumber()
+  scheduleMs?: number;
+}
+
+@ApiTags('webhooks')
+@Controller('api/webhooks')
+export class WebhooksController {
+  constructor(private readonly service: WebhooksService) {}
+
+  @Post('receive/:endpoint(*)')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Receive and store an incoming webhook event' })
+  @ApiParam({ name: 'endpoint', description: 'Endpoint path (wildcarded)' })
+  receive(
+    @Param('endpoint') endpoint: string,
+    @Req() req: Request,
+    @Headers() headers: Record<string, string>,
+    @Body() body: unknown,
+    @Query('secret') secret?: string,
+  ): WebhookEvent {
+    return this.service.receiveWebhook(
+      `/${endpoint}`,
+      req.method,
+      headers,
+      body,
+      secret,
+    );
+  }
+
+  @Get('events')
+  @ApiOperation({ summary: 'List received webhook events' })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'endpoint', required: false })
+  list(
+    @Query('limit') limit?: string,
+    @Query('endpoint') endpoint?: string,
+  ): WebhookEvent[] {
+    return this.service.listEvents(limit ? parseInt(limit) : 50, endpoint);
+  }
+
+  @Get('events/:id')
+  @ApiOperation({ summary: 'Get a webhook event by ID' })
+  getEvent(@Param('id') id: string) {
+    return this.service.getEvent(id);
+  }
+
+  @Post('events/:id/replay')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replay a webhook event to its original endpoint' })
+  @ApiQuery({ name: 'targetUrl', required: false })
+  replay(@Param('id') id: string, @Query('targetUrl') targetUrl?: string) {
+    return this.service.replayEvent(id, targetUrl);
+  }
+
+  @Delete('events')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Clear all stored webhook events' })
+  clear(): void {
+    this.service.clearEvents();
+  }
+
+  @Get('simulations')
+  @ApiOperation({ summary: 'List webhook simulations' })
+  listSims(): WebhookSimulation[] {
+    return this.service.listSimulations();
+  }
+
+  @Post('simulations')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a fake webhook simulation' })
+  createSim(@Body() dto: CreateSimulationDto): WebhookSimulation {
+    return this.service.createSimulation(
+      dto.name,
+      dto.targetUrl,
+      dto.method ?? 'POST',
+      dto.headers ?? {},
+      dto.payload ?? {},
+      dto.scheduleMs,
+    );
+  }
+
+  @Post('simulations/:id/fire')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Fire a webhook simulation to its target URL' })
+  fireSim(@Param('id') id: string) {
+    return this.service.fireSimulation(id);
+  }
+}

--- a/packages/api/src/webhooks/webhooks.module.ts
+++ b/packages/api/src/webhooks/webhooks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+
+@Module({
+  controllers: [WebhooksController],
+  providers: [WebhooksService],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/packages/api/src/webhooks/webhooks.service.ts
+++ b/packages/api/src/webhooks/webhooks.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface WebhookEvent {
+  id: string;
+  endpoint: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+  receivedAt: string;
+  signature?: string;
+  verified?: boolean;
+}
+
+export interface WebhookSimulation {
+  id: string;
+  name: string;
+  targetUrl: string;
+  method: string;
+  headers: Record<string, string>;
+  payload: unknown;
+  scheduleMs?: number;
+  createdAt: string;
+}
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+  private readonly storageDir: string;
+  private readonly eventsFile: string;
+  private readonly simsFile: string;
+
+  constructor(private readonly config: ConfigService) {
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.storageDir = path.join(mocksDir, 'webhooks');
+    fs.mkdirSync(this.storageDir, { recursive: true });
+    this.eventsFile = path.join(this.storageDir, 'events.json');
+    this.simsFile = path.join(this.storageDir, 'simulations.json');
+  }
+
+  receiveWebhook(
+    endpoint: string,
+    method: string,
+    headers: Record<string, string>,
+    body: unknown,
+    secret?: string,
+  ): WebhookEvent {
+    const raw = typeof body === 'string' ? body : JSON.stringify(body);
+    const signature = headers['x-hub-signature-256'] ?? headers['x-signature'] ?? '';
+    let verified = false;
+
+    if (secret && signature) {
+      const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(raw).digest('hex');
+      verified = expected === signature;
+    }
+
+    const event: WebhookEvent = {
+      id: uuidv4(),
+      endpoint,
+      method,
+      headers,
+      body,
+      receivedAt: new Date().toISOString(),
+      signature: signature || undefined,
+      verified,
+    };
+
+    const events = this.loadEvents();
+    events.unshift(event);
+    fs.writeFileSync(this.eventsFile, JSON.stringify(events.slice(0, 500), null, 2));
+    this.logger.log(`Webhook received: ${method} ${endpoint} (verified: ${verified})`);
+    return event;
+  }
+
+  listEvents(limit = 50, endpoint?: string): WebhookEvent[] {
+    let events = this.loadEvents();
+    if (endpoint) events = events.filter((e) => e.endpoint === endpoint);
+    return events.slice(0, limit);
+  }
+
+  getEvent(id: string): WebhookEvent | undefined {
+    return this.loadEvents().find((e) => e.id === id);
+  }
+
+  clearEvents(): void {
+    fs.writeFileSync(this.eventsFile, '[]');
+  }
+
+  async replayEvent(id: string, targetUrl?: string): Promise<{ status: number; ok: boolean }> {
+    const event = this.getEvent(id);
+    if (!event) throw new Error(`Event not found: ${id}`);
+
+    const url = targetUrl ?? event.endpoint;
+    try {
+      const res = await fetch(url, {
+        method: event.method,
+        headers: event.headers,
+        body: event.method !== 'GET' ? JSON.stringify(event.body) : undefined,
+        signal: AbortSignal.timeout(10_000),
+      });
+      return { status: res.status, ok: res.ok };
+    } catch (err) {
+      throw new Error(`Replay failed: ${(err as Error).message}`);
+    }
+  }
+
+  createSimulation(
+    name: string,
+    targetUrl: string,
+    method: string,
+    headers: Record<string, string>,
+    payload: unknown,
+    scheduleMs?: number,
+  ): WebhookSimulation {
+    const sim: WebhookSimulation = {
+      id: uuidv4(),
+      name,
+      targetUrl,
+      method,
+      headers,
+      payload,
+      scheduleMs,
+      createdAt: new Date().toISOString(),
+    };
+    const sims = this.loadSimulations();
+    sims.push(sim);
+    fs.writeFileSync(this.simsFile, JSON.stringify(sims, null, 2));
+    return sim;
+  }
+
+  listSimulations(): WebhookSimulation[] {
+    return this.loadSimulations();
+  }
+
+  async fireSimulation(id: string): Promise<{ status: number; ok: boolean }> {
+    const sim = this.loadSimulations().find((s) => s.id === id);
+    if (!sim) throw new Error(`Simulation not found: ${id}`);
+
+    const res = await fetch(sim.targetUrl, {
+      method: sim.method,
+      headers: { 'Content-Type': 'application/json', ...sim.headers },
+      body: sim.method !== 'GET' ? JSON.stringify(sim.payload) : undefined,
+      signal: AbortSignal.timeout(10_000),
+    });
+    return { status: res.status, ok: res.ok };
+  }
+
+  private loadEvents(): WebhookEvent[] {
+    if (!fs.existsSync(this.eventsFile)) return [];
+    try {
+      return JSON.parse(fs.readFileSync(this.eventsFile, 'utf-8')) as WebhookEvent[];
+    } catch { return []; }
+  }
+
+  private loadSimulations(): WebhookSimulation[] {
+    if (!fs.existsSync(this.simsFile)) return [];
+    try {
+      return JSON.parse(fs.readFileSync(this.simsFile, 'utf-8')) as WebhookSimulation[];
+    } catch { return []; }
+  }
+}

--- a/packages/mcp/stubrix-mcp/src/index.js
+++ b/packages/mcp/stubrix-mcp/src/index.js
@@ -1114,6 +1114,182 @@ server.tool(
 );
 
 // ===========================================================================
+// Webhooks — Receiver, Replay & Simulator (F25)
+// ===========================================================================
+
+server.tool(
+  "webhook_list_events",
+  "List received webhook events.",
+  {
+    limit: z.number().optional().describe("Max events to return (default 50)"),
+    endpoint: z.string().optional().describe("Filter by endpoint path"),
+  },
+  async ({ limit, endpoint }) => {
+    const params = new URLSearchParams();
+    if (limit) params.set("limit", String(limit));
+    if (endpoint) params.set("endpoint", endpoint);
+    return api(`/api/webhooks/events?${params}`);
+  },
+);
+
+server.tool(
+  "webhook_replay",
+  "Replay a received webhook event to its original (or a new) target URL.",
+  {
+    id: z.string().describe("Webhook event ID"),
+    targetUrl: z.string().optional().describe("Override target URL"),
+  },
+  async ({ id, targetUrl }) => {
+    const params = targetUrl ? `?targetUrl=${encodeURIComponent(targetUrl)}` : "";
+    return api(`/api/webhooks/events/${id}/replay${params}`, { method: "POST" });
+  },
+);
+
+server.tool(
+  "webhook_clear",
+  "Clear all stored webhook events.",
+  {},
+  async () => api("/api/webhooks/events", { method: "DELETE" }),
+);
+
+server.tool(
+  "webhook_create_simulation",
+  "Create a fake webhook simulation to fire at a target URL.",
+  {
+    name: z.string().describe("Simulation name"),
+    targetUrl: z.string().describe("URL to send the webhook to"),
+    method: z.string().optional().describe("HTTP method (default POST)"),
+    payload: z.record(z.unknown()).optional().describe("Webhook payload"),
+  },
+  async ({ name, targetUrl, method, payload }) =>
+    api("/api/webhooks/simulations", {
+      method: "POST",
+      body: JSON.stringify({ name, targetUrl, method: method ?? "POST", payload: payload ?? {} }),
+    }),
+);
+
+server.tool(
+  "webhook_fire_simulation",
+  "Fire a webhook simulation to its configured target URL.",
+  {
+    id: z.string().describe("Simulation UUID"),
+  },
+  async ({ id }) => api(`/api/webhooks/simulations/${id}/fire`, { method: "POST" }),
+);
+
+// ===========================================================================
+// Events — Kafka & RabbitMQ (F16)
+// ===========================================================================
+
+server.tool(
+  "event_publish",
+  "Publish an event to Kafka (Redpanda) or RabbitMQ.",
+  {
+    broker: z.enum(["kafka", "rabbitmq"]).describe("Message broker"),
+    topic: z.string().describe("Kafka topic or RabbitMQ exchange name"),
+    payload: z.record(z.unknown()).describe("Event payload"),
+  },
+  async ({ broker, topic, payload }) =>
+    api("/api/events/publish", {
+      method: "POST",
+      body: JSON.stringify({ broker, topic, payload }),
+    }),
+);
+
+server.tool(
+  "event_list_templates",
+  "List saved event templates.",
+  {},
+  async () => api("/api/events/templates"),
+);
+
+server.tool(
+  "event_create_template",
+  "Create a reusable event template for Kafka or RabbitMQ.",
+  {
+    name: z.string().describe("Template name"),
+    broker: z.enum(["kafka", "rabbitmq"]),
+    topic: z.string().describe("Kafka topic or RabbitMQ exchange"),
+    payload: z.record(z.unknown()).describe("Event payload"),
+  },
+  async ({ name, broker, topic, payload }) =>
+    api("/api/events/templates", {
+      method: "POST",
+      body: JSON.stringify({ name, broker, topic, payload }),
+    }),
+);
+
+server.tool(
+  "event_fire_template",
+  "Fire a saved event template.",
+  {
+    id: z.string().describe("Template UUID"),
+  },
+  async ({ id }) => api(`/api/events/templates/${id}/fire`, { method: "POST" }),
+);
+
+server.tool(
+  "event_health",
+  "Check Kafka and RabbitMQ availability.",
+  {},
+  async () => api("/api/events/health"),
+);
+
+// ===========================================================================
+// Protocols — GraphQL & gRPC (F15)
+// ===========================================================================
+
+server.tool(
+  "protocol_list_mocks",
+  "List protocol mocks (graphql, grpc, rest).",
+  {
+    protocol: z.enum(["graphql", "grpc", "rest"]).optional().describe("Filter by protocol"),
+  },
+  async ({ protocol }) => {
+    const params = protocol ? `?protocol=${protocol}` : "";
+    return api(`/api/protocols/mocks${params}`);
+  },
+);
+
+server.tool(
+  "protocol_create_mock",
+  "Create a GraphQL or gRPC protocol mock.",
+  {
+    protocol: z.enum(["graphql", "grpc", "rest"]).describe("Protocol type"),
+    name: z.string().describe("Mock name"),
+    schema: z.string().optional().describe("GraphQL SDL schema string"),
+    protoFile: z.string().optional().describe("Protobuf file content (gRPC)"),
+    grpcService: z.string().optional().describe("gRPC service name"),
+    endpoint: z.string().optional().describe("Endpoint URL"),
+  },
+  async ({ protocol, name, schema, protoFile, grpcService, endpoint }) =>
+    api("/api/protocols/mocks", {
+      method: "POST",
+      body: JSON.stringify({ protocol, name, schema, protoFile, grpcService, endpoint }),
+    }),
+);
+
+server.tool(
+  "protocol_parse_graphql",
+  "Parse a GraphQL schema and return a summary of types, queries, mutations and subscriptions.",
+  {
+    schema: z.string().describe("GraphQL SDL schema"),
+  },
+  async ({ schema }) =>
+    api("/api/protocols/graphql/parse", {
+      method: "POST",
+      body: JSON.stringify({ schema }),
+    }),
+);
+
+server.tool(
+  "protocol_grpc_health",
+  "Check if GripMock (gRPC mock engine) is available.",
+  {},
+  async () => api("/api/protocols/grpc/health"),
+);
+
+// ===========================================================================
 // Governance — Spectral Lint (F12)
 // ===========================================================================
 


### PR DESCRIPTION
## 📝 Descrição

Implementação completa do milestone **v2.0.0 — Multi-Protocol & Events** cobrindo 3 épicos.

## 🔗 Issues Relacionadas

Closes #97
Closes #98
Closes #99
Closes #100
Closes #101
Closes #102
Closes #103
Closes #104
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #169
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174
Closes #36
Closes #38
Closes #47

## 🎯 O que foi implementado

### F25 — Webhook Testing (#169-#174)
- **F25.01-02** `WebhooksService` — receiver com persistência (até 500 eventos)
- **F25.03** Verificação de assinatura HMAC (x-hub-signature-256 / x-signature)
- **F25.04** `replayEvent()` — replay para URL original ou customizada
- **F25.05** `createSimulation() + fireSimulation()` — webhooks falsos
- **F25.06** `WebhooksController` + 5 MCP tools

### F16 — Event-Driven Mocking (#112-#118)
- **F16.01** Redpanda profile 'kafka' (:9092 + :8082 REST + :8080 Console)
- **F16.02** RabbitMQ profile 'rabbitmq' (:5672 + :15672 management)
- **F16.03-06** `EventsService` — publish para Kafka/RabbitMQ com fallback, templates CRUD
- **F16.07** `EventsController` + 5 MCP tools; Makefile kafka-up/down/logs, rabbitmq-up/down/logs

### F15 — GraphQL & gRPC (#97-#104)
- **F15.01-03** `ProtocolsService` com registry, parser de GraphQL SDL
- **F15.06** GripMock profile 'gripmock' (:4770 gRPC + :4771 stub API)
- **F15.08** `ProtocolsController` + 4 MCP tools; Makefile gripmock-up/down