### PR TITLE
✨ feat(api): F21 + F22 + F28 — Metrics, Performance Testing, Distributed Tracing (v2.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,26 @@ SQLITE_DB_PATH=
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
 
+# Prometheus – Metrics scraping (F21.03)
+PROMETHEUS_PORT=9091
+
+# Grafana – Dashboards (F21.04)
+GRAFANA_PORT=3000
+GRAFANA_USER=admin
+GRAFANA_PASS=admin
+
+# Jaeger – Distributed tracing (F28.01)
+JAEGER_UI_PORT=16686
+JAEGER_URL=http://localhost:16686
+
+# OpenTelemetry (F28.02)
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=stubrix
+OTEL_EXPORTER_ENDPOINT=http://localhost:4318
+OTEL_HTTP_PORT=4318
+OTEL_GRPC_PORT=4317
+OTEL_SAMPLING_RATE=1.0
+
 # Kafka / Redpanda – Event-driven mocking (F16.01)
 KAFKA_PORT=9092
 KAFKA_REST_PORT=8082

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@
         toxiproxy-up toxiproxy-down toxiproxy-logs \
         kafka-up kafka-down kafka-logs \
         rabbitmq-up rabbitmq-down rabbitmq-logs \
-        gripmock-up gripmock-down
+        gripmock-up gripmock-down \
+        monitoring-up monitoring-down \
+        jaeger-up jaeger-down
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -183,6 +185,18 @@ gripmock-up: ## Start GripMock gRPC mock engine (F15.06 — detached)
 gripmock-down: ## Stop GripMock
 	docker compose --profile gripmock down
 
+monitoring-up: ## Start Prometheus + Grafana (F21.03/04 — detached)
+	docker compose --profile monitoring up -d
+
+monitoring-down: ## Stop Prometheus + Grafana
+	docker compose --profile monitoring down
+
+jaeger-up: ## Start Jaeger distributed tracing (F28.01 — detached)
+	docker compose --profile jaeger up -d
+
+jaeger-down: ## Stop Jaeger
+	docker compose --profile jaeger down
+
 hoppscotch: ## Start Hoppscotch self-hosted API client (F8.01 — http://localhost:3100)
 	docker compose --profile hoppscotch up
 
@@ -201,7 +215,7 @@ bruno-test-collection: ## Run Bruno tests for a specific collection (e.g. make b
 	COLLECTION=$(COLLECTION) bash scripts/bruno-test.sh
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -225,7 +239,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'stubrix-api'
+    static_configs:
+      - targets: ['host.docker.internal:9090']
+    metrics_path: /api/metrics/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,12 @@
 ## gRPC (F15):
 ##   docker compose --profile gripmock up -d            # GripMock → :4770 / :4771
 ##
+## Observability (F21):
+##   docker compose --profile monitoring up -d           # Prometheus :9091 + Grafana :3000
+##
+## Tracing (F28):
+##   docker compose --profile jaeger up -d              # Jaeger → :16686 / :4318
+##
 ## Network Chaos (F26):
 ##   docker compose --profile toxiproxy up -d          # Toxiproxy → http://localhost:8474
 ##
@@ -194,6 +200,58 @@ services:
     volumes:
       - cloudbeaver_data:/opt/cloudbeaver/workspace
       - ./config/cloudbeaver:/opt/cloudbeaver/conf:ro
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Prometheus – Metrics scraping (F21.03)
+  # Access: http://localhost:9091
+  # --------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:latest
+    profiles: ["prometheus", "monitoring"]
+    container_name: stubrix-prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9091}:9090"
+    volumes:
+      - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Grafana – Metrics dashboards (F21.04)
+  # Access: http://localhost:3000 (admin/admin)
+  # --------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana-oss:latest
+    profiles: ["grafana", "monitoring"]
+    container_name: stubrix-grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASS:-admin}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./config/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Jaeger – Distributed tracing (F28.01)
+  # UI: http://localhost:16686 | OTLP HTTP: :4318 | OTLP gRPC: :4317
+  # --------------------------------------------------------------------------
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    profiles: ["jaeger", "tracing"]
+    container_name: stubrix-jaeger
+    ports:
+      - "${JAEGER_UI_PORT:-16686}:16686"
+      - "${OTEL_HTTP_PORT:-4318}:4318"
+      - "${OTEL_GRPC_PORT:-4317}:4317"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
     restart: unless-stopped
 
   # --------------------------------------------------------------------------
@@ -363,5 +421,7 @@ volumes:
   pg_data:
   mysql_data:
   cloudbeaver_data:
+  prometheus_data:
+  grafana_data:
   chromadb_data:
   pact_data:

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -24,6 +24,9 @@ import { EventsModule } from './events/events.module';
 import { ProtocolsModule } from './protocols/protocols.module';
 import { AuthModule } from './auth/auth.module';
 import { TemplatesModule } from './templates/templates.module';
+import { MetricsModule } from './metrics/metrics.module';
+import { PerformanceModule } from './performance/performance.module';
+import { TracingModule } from './tracing/tracing.module';
 
 export function setupSwagger(app: any) {
   const config = new DocumentBuilder()
@@ -50,6 +53,9 @@ export function setupSwagger(app: any) {
     .addTag('protocols', 'Multi-protocol mocks — GraphQL & gRPC')
     .addTag('auth', 'Authentication, API keys, RBAC & multi-tenancy')
     .addTag('templates', 'Environment templates & blueprints')
+    .addTag('metrics', 'Prometheus metrics & health checks')
+    .addTag('performance', 'k6 performance testing & baselines')
+    .addTag('tracing', 'Distributed tracing — Jaeger & OpenTelemetry')
     .addTag('status', 'System status')
     .addServer('http://localhost:9090', 'Development server')
     .addServer('https://api.stubrix.com', 'Production server')
@@ -105,6 +111,9 @@ export function setupSwagger(app: any) {
     ProtocolsModule,
     AuthModule,
     TemplatesModule,
+    MetricsModule,
+    PerformanceModule,
+    TracingModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/metrics/metrics.controller.ts
+++ b/packages/api/src/metrics/metrics.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { MetricsService } from './metrics.service';
+
+@ApiTags('metrics')
+@Controller('api/metrics')
+export class MetricsController {
+  constructor(private readonly service: MetricsService) {}
+
+  @Get('prometheus')
+  @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  @ApiOperation({ summary: 'Prometheus scrape endpoint — /metrics compatible format' })
+  prometheus(): string {
+    return this.service.getPrometheusText();
+  }
+
+  @Get('summary')
+  @ApiOperation({ summary: 'Get metrics summary (counters, histograms)' })
+  summary() {
+    return this.service.getMetricsSummary();
+  }
+
+  @Get('health')
+  @ApiOperation({ summary: 'Detailed health check — all services + latencies' })
+  health() {
+    return this.service.getHealthStatus();
+  }
+}

--- a/packages/api/src/metrics/metrics.module.ts
+++ b/packages/api/src/metrics/metrics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {}

--- a/packages/api/src/metrics/metrics.service.ts
+++ b/packages/api/src/metrics/metrics.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface MetricCounter {
+  name: string;
+  help: string;
+  value: number;
+  labels?: Record<string, string>;
+}
+
+export interface HealthStatus {
+  status: 'ok' | 'degraded' | 'error';
+  uptime: number;
+  version: string;
+  checks: Record<string, { status: 'ok' | 'error'; latencyMs?: number; detail?: string }>;
+  timestamp: string;
+}
+
+@Injectable()
+export class MetricsService {
+  private readonly logger = new Logger(MetricsService.name);
+  private readonly counters = new Map<string, number>();
+  private readonly histograms = new Map<string, number[]>();
+  private readonly startTime = Date.now();
+
+  constructor(private readonly config: ConfigService) {}
+
+  increment(name: string, value = 1): void {
+    this.counters.set(name, (this.counters.get(name) ?? 0) + value);
+  }
+
+  observe(name: string, value: number): void {
+    const bucket = this.histograms.get(name) ?? [];
+    bucket.push(value);
+    if (bucket.length > 1000) bucket.shift();
+    this.histograms.set(name, bucket);
+  }
+
+  getPrometheusText(): string {
+    const lines: string[] = [];
+
+    lines.push('# HELP stubrix_uptime_seconds API uptime in seconds');
+    lines.push('# TYPE stubrix_uptime_seconds gauge');
+    lines.push(`stubrix_uptime_seconds ${Math.floor((Date.now() - this.startTime) / 1000)}`);
+
+    for (const [name, value] of this.counters.entries()) {
+      const metricName = `stubrix_${name.replace(/[^a-z0-9_]/gi, '_')}`;
+      lines.push(`# HELP ${metricName} Stubrix counter: ${name}`);
+      lines.push(`# TYPE ${metricName} counter`);
+      lines.push(`${metricName} ${value}`);
+    }
+
+    for (const [name, values] of this.histograms.entries()) {
+      if (values.length === 0) continue;
+      const metricName = `stubrix_${name.replace(/[^a-z0-9_]/gi, '_')}`;
+      const sorted = [...values].sort((a, b) => a - b);
+      const sum = sorted.reduce((a, b) => a + b, 0);
+      const p50 = sorted[Math.floor(sorted.length * 0.5)] ?? 0;
+      const p95 = sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+      const p99 = sorted[Math.floor(sorted.length * 0.99)] ?? 0;
+
+      lines.push(`# HELP ${metricName}_ms Histogram for ${name} in ms`);
+      lines.push(`# TYPE ${metricName}_ms summary`);
+      lines.push(`${metricName}_ms{quantile="0.5"} ${p50}`);
+      lines.push(`${metricName}_ms{quantile="0.95"} ${p95}`);
+      lines.push(`${metricName}_ms{quantile="0.99"} ${p99}`);
+      lines.push(`${metricName}_ms_sum ${sum}`);
+      lines.push(`${metricName}_ms_count ${values.length}`);
+    }
+
+    return lines.join('\n') + '\n';
+  }
+
+  getMetricsSummary(): Record<string, unknown> {
+    const summary: Record<string, unknown> = {
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      counters: Object.fromEntries(this.counters),
+    };
+
+    const histSummary: Record<string, unknown> = {};
+    for (const [name, values] of this.histograms.entries()) {
+      if (values.length === 0) continue;
+      const sorted = [...values].sort((a, b) => a - b);
+      histSummary[name] = {
+        count: values.length,
+        avg: Math.round(sorted.reduce((a, b) => a + b, 0) / sorted.length),
+        p50: sorted[Math.floor(sorted.length * 0.5)],
+        p95: sorted[Math.floor(sorted.length * 0.95)],
+        p99: sorted[Math.floor(sorted.length * 0.99)],
+      };
+    }
+    summary['histograms'] = histSummary;
+
+    return summary;
+  }
+
+  async getHealthStatus(): Promise<HealthStatus> {
+    const checks: HealthStatus['checks'] = {};
+    const apiUrl = `http://localhost:${this.config.get<string>('API_PORT') ?? '9090'}`;
+
+    const externalChecks = [
+      { name: 'pact-broker', url: `${this.config.get<string>('PACT_BROKER_URL') ?? 'http://localhost:9292'}/` },
+      { name: 'toxiproxy', url: `${this.config.get<string>('TOXIPROXY_URL') ?? 'http://localhost:8474'}/version` },
+      { name: 'rag', url: `${this.config.get<string>('OPENRAG_URL') ?? 'http://localhost:8888'}/health` },
+    ];
+
+    checks['api'] = { status: 'ok', detail: 'running' };
+
+    for (const check of externalChecks) {
+      const t0 = Date.now();
+      try {
+        const res = await fetch(check.url, { signal: AbortSignal.timeout(2_000) });
+        checks[check.name] = { status: res.ok ? 'ok' : 'error', latencyMs: Date.now() - t0 };
+      } catch {
+        checks[check.name] = { status: 'error', detail: 'unreachable' };
+      }
+    }
+
+    const hasError = Object.values(checks).some((c) => c.status === 'error');
+
+    return {
+      status: hasError ? 'degraded' : 'ok',
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      version: this.config.get<string>('npm_package_version') ?? '1.3.1',
+      checks,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/packages/api/src/performance/performance.controller.ts
+++ b/packages/api/src/performance/performance.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { IsString, IsOptional, IsObject } from 'class-validator';
+import { PerformanceService } from './performance.service';
+import type { PerformanceBaseline } from './performance.service';
+import type { Response } from 'express';
+
+export class CreateScriptDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  script: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsObject()
+  options?: { vus?: number; duration?: string; thresholds?: Record<string, string[]> };
+}
+
+export class SaveBaselineDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  scriptId: string;
+
+  @IsObject()
+  metrics: PerformanceBaseline['metrics'];
+}
+
+export class CompareBaselineDto {
+  @IsObject()
+  current: PerformanceBaseline['metrics'];
+}
+
+@ApiTags('performance')
+@Controller('api/performance')
+export class PerformanceController {
+  constructor(private readonly service: PerformanceService) {}
+
+  @Get('scripts')
+  @ApiOperation({ summary: 'List k6 test scripts (built-in + custom)' })
+  @ApiQuery({ name: 'builtIn', required: false })
+  listScripts(@Query('builtIn') builtIn?: string) {
+    return this.service.listScripts(builtIn !== 'false');
+  }
+
+  @Post('scripts')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a custom k6 test script' })
+  createScript(@Body() dto: CreateScriptDto) {
+    return this.service.createScript(dto.name, dto.script, dto.options ?? {}, dto.description);
+  }
+
+  @Get('scripts/:id/export')
+  @ApiOperation({ summary: 'Export a k6 script as plain JS text' })
+  @ApiParam({ name: 'id' })
+  exportScript(@Param('id') id: string, @Res() res: Response): void {
+    const content = this.service.exportScript(id);
+    res.setHeader('Content-Type', 'application/javascript');
+    res.setHeader('Content-Disposition', `attachment; filename="${id}.js"`);
+    res.send(content);
+  }
+
+  @Get('baselines')
+  @ApiOperation({ summary: 'List performance baselines' })
+  listBaselines() {
+    return this.service.listBaselines();
+  }
+
+  @Post('baselines')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Save a new performance baseline' })
+  saveBaseline(@Body() dto: SaveBaselineDto) {
+    return this.service.saveBaseline(dto.name, dto.scriptId, dto.metrics);
+  }
+
+  @Post('baselines/:id/compare')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Compare current metrics against a baseline (CI gate)' })
+  @ApiParam({ name: 'id' })
+  compare(@Param('id') id: string, @Body() dto: CompareBaselineDto) {
+    return this.service.compareBaseline(id, dto.current);
+  }
+}

--- a/packages/api/src/performance/performance.module.ts
+++ b/packages/api/src/performance/performance.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PerformanceController } from './performance.controller';
+import { PerformanceService } from './performance.service';
+
+@Module({
+  controllers: [PerformanceController],
+  providers: [PerformanceService],
+  exports: [PerformanceService],
+})
+export class PerformanceModule {}

--- a/packages/api/src/performance/performance.service.ts
+++ b/packages/api/src/performance/performance.service.ts
@@ -1,0 +1,204 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface K6Script {
+  id: string;
+  name: string;
+  description?: string;
+  script: string;
+  options: {
+    vus?: number;
+    duration?: string;
+    thresholds?: Record<string, string[]>;
+  };
+  createdAt: string;
+}
+
+export interface PerformanceBaseline {
+  id: string;
+  name: string;
+  scriptId: string;
+  metrics: {
+    p95ResponseMs: number;
+    p99ResponseMs: number;
+    errorRate: number;
+    requestsPerSec: number;
+  };
+  createdAt: string;
+}
+
+const BUILT_IN_SCRIPTS: K6Script[] = [
+  {
+    id: 'builtin-smoke',
+    name: 'Smoke Test',
+    description: 'Minimal load to verify the mock server is working',
+    script: `import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  vus: 1,
+  duration: '30s',
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const res = http.get(__ENV.BASE_URL || 'http://localhost:8081/api/health');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}`,
+    options: { vus: 1, duration: '30s' },
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-load',
+    name: 'Load Test',
+    description: 'Sustained load to measure throughput and p95 latency',
+    script: `import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 20 },
+    { duration: '1m', target: 20 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<1000'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+export default function () {
+  const res = http.get(__ENV.BASE_URL || 'http://localhost:8081/api/health');
+  check(res, { 'status 2xx': (r) => r.status >= 200 && r.status < 300 });
+  sleep(0.1);
+}`,
+    options: { vus: 20, duration: '2m' },
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'builtin-stress',
+    name: 'Stress Test',
+    description: 'Ramp up to find the breaking point',
+    script: `import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 50 },
+    { duration: '1m', target: 100 },
+    { duration: '30s', target: 0 },
+  ],
+};
+
+export default function () {
+  const res = http.get(__ENV.BASE_URL || 'http://localhost:8081/api/health');
+  check(res, { 'status 2xx': (r) => r.status >= 200 && r.status < 300 });
+}`,
+    options: { vus: 100, duration: '2m' },
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+@Injectable()
+export class PerformanceService {
+  private readonly logger = new Logger(PerformanceService.name);
+  private readonly storageDir: string;
+  private readonly scriptsFile: string;
+  private readonly baselinesFile: string;
+
+  constructor(private readonly config: ConfigService) {
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.storageDir = path.join(mocksDir, 'performance');
+    this.scriptsFile = path.join(this.storageDir, 'scripts.json');
+    this.baselinesFile = path.join(this.storageDir, 'baselines.json');
+    fs.mkdirSync(this.storageDir, { recursive: true });
+  }
+
+  listScripts(includeBuiltIn = true): K6Script[] {
+    const custom = this.loadScripts();
+    return includeBuiltIn ? [...BUILT_IN_SCRIPTS, ...custom] : custom;
+  }
+
+  createScript(
+    name: string,
+    script: string,
+    options: K6Script['options'],
+    description?: string,
+  ): K6Script {
+    const s: K6Script = {
+      id: uuidv4(),
+      name,
+      description,
+      script,
+      options,
+      createdAt: new Date().toISOString(),
+    };
+    const scripts = this.loadScripts();
+    scripts.push(s);
+    fs.writeFileSync(this.scriptsFile, JSON.stringify(scripts, null, 2));
+    return s;
+  }
+
+  exportScript(id: string): string {
+    const script = this.listScripts().find((s) => s.id === id);
+    if (!script) throw new Error(`Script not found: ${id}`);
+    return script.script;
+  }
+
+  listBaselines(): PerformanceBaseline[] {
+    if (!fs.existsSync(this.baselinesFile)) return [];
+    try { return JSON.parse(fs.readFileSync(this.baselinesFile, 'utf-8')) as PerformanceBaseline[]; }
+    catch { return []; }
+  }
+
+  saveBaseline(
+    name: string,
+    scriptId: string,
+    metrics: PerformanceBaseline['metrics'],
+  ): PerformanceBaseline {
+    const baseline: PerformanceBaseline = {
+      id: uuidv4(),
+      name,
+      scriptId,
+      metrics,
+      createdAt: new Date().toISOString(),
+    };
+    const baselines = this.listBaselines();
+    baselines.push(baseline);
+    fs.writeFileSync(this.baselinesFile, JSON.stringify(baselines, null, 2));
+    return baseline;
+  }
+
+  compareBaseline(
+    id: string,
+    current: PerformanceBaseline['metrics'],
+  ): { passed: boolean; regressions: string[] } {
+    const baseline = this.listBaselines().find((b) => b.id === id);
+    if (!baseline) throw new Error(`Baseline not found: ${id}`);
+
+    const regressions: string[] = [];
+    const b = baseline.metrics;
+
+    if (current.p95ResponseMs > b.p95ResponseMs * 1.2)
+      regressions.push(`p95 latency regressed: ${current.p95ResponseMs}ms vs baseline ${b.p95ResponseMs}ms`);
+    if (current.errorRate > b.errorRate + 0.01)
+      regressions.push(`Error rate regressed: ${(current.errorRate * 100).toFixed(1)}% vs baseline ${(b.errorRate * 100).toFixed(1)}%`);
+    if (current.requestsPerSec < b.requestsPerSec * 0.8)
+      regressions.push(`Throughput regressed: ${current.requestsPerSec.toFixed(1)} rps vs baseline ${b.requestsPerSec.toFixed(1)} rps`);
+
+    return { passed: regressions.length === 0, regressions };
+  }
+
+  private loadScripts(): K6Script[] {
+    if (!fs.existsSync(this.scriptsFile)) return [];
+    try { return JSON.parse(fs.readFileSync(this.scriptsFile, 'utf-8')) as K6Script[]; }
+    catch { return []; }
+  }
+}

--- a/packages/api/src/tracing/tracing.controller.ts
+++ b/packages/api/src/tracing/tracing.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { TracingService } from './tracing.service';
+
+@ApiTags('tracing')
+@Controller('api/tracing')
+export class TracingController {
+  constructor(private readonly service: TracingService) {}
+
+  @Get('traces')
+  @ApiOperation({ summary: 'List recent distributed traces' })
+  @ApiQuery({ name: 'service', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  list(@Query('service') service?: string, @Query('limit') limit?: string) {
+    return this.service.listTraces(service, limit ? parseInt(limit) : 20);
+  }
+
+  @Get('traces/:traceId')
+  @ApiOperation({ summary: 'Get a trace by ID' })
+  @ApiParam({ name: 'traceId' })
+  get(@Param('traceId') traceId: string) {
+    return this.service.getTrace(traceId);
+  }
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check Jaeger availability' })
+  health() {
+    return this.service.jaegerHealth();
+  }
+
+  @Get('config')
+  @ApiOperation({ summary: 'Get OpenTelemetry configuration' })
+  config() {
+    return this.service.getOtelConfig();
+  }
+}

--- a/packages/api/src/tracing/tracing.module.ts
+++ b/packages/api/src/tracing/tracing.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TracingController } from './tracing.controller';
+import { TracingService } from './tracing.service';
+
+@Module({
+  controllers: [TracingController],
+  providers: [TracingService],
+  exports: [TracingService],
+})
+export class TracingModule {}

--- a/packages/api/src/tracing/tracing.service.ts
+++ b/packages/api/src/tracing/tracing.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface Span {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  operationName: string;
+  service: string;
+  startTime: number;
+  duration: number;
+  tags?: Record<string, string | number | boolean>;
+  status: 'ok' | 'error';
+}
+
+export interface Trace {
+  traceId: string;
+  spans: Span[];
+  duration: number;
+  service: string;
+  timestamp: string;
+}
+
+@Injectable()
+export class TracingService {
+  private readonly logger = new Logger(TracingService.name);
+  private readonly jaegerUrl: string;
+  private readonly storageDir: string;
+  private readonly tracesFile: string;
+  private readonly enabled: boolean;
+
+  constructor(private readonly config: ConfigService) {
+    this.jaegerUrl = this.config.get<string>('JAEGER_URL') ?? 'http://localhost:16686';
+    this.enabled = this.config.get<string>('OTEL_ENABLED') !== 'false';
+    const mocksDir =
+      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+    this.storageDir = path.join(mocksDir, 'traces');
+    this.tracesFile = path.join(this.storageDir, 'traces.json');
+    fs.mkdirSync(this.storageDir, { recursive: true });
+  }
+
+  startSpan(operationName: string, service = 'stubrix-api', parentSpanId?: string): Span {
+    return {
+      traceId: uuidv4().replace(/-/g, ''),
+      spanId: uuidv4().replace(/-/g, '').slice(0, 16),
+      parentSpanId,
+      operationName,
+      service,
+      startTime: Date.now(),
+      duration: 0,
+      status: 'ok',
+    };
+  }
+
+  finishSpan(span: Span, tags?: Record<string, string | number | boolean>, error?: Error): Span {
+    span.duration = Date.now() - span.startTime;
+    span.tags = tags;
+    if (error) {
+      span.status = 'error';
+      span.tags = { ...span.tags, 'error.message': error.message };
+    }
+    this.recordSpan(span);
+    return span;
+  }
+
+  listTraces(service?: string, limit = 20): Trace[] {
+    const traces = this.loadTraces();
+    const filtered = service ? traces.filter((t) => t.service === service) : traces;
+    return filtered.slice(0, limit);
+  }
+
+  getTrace(traceId: string): Trace | undefined {
+    return this.loadTraces().find((t) => t.traceId === traceId);
+  }
+
+  async jaegerHealth(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.jaegerUrl}/`, { signal: AbortSignal.timeout(3_000) });
+      return { available: res.ok, url: this.jaegerUrl };
+    } catch {
+      return { available: false, url: this.jaegerUrl };
+    }
+  }
+
+  getOtelConfig(): Record<string, unknown> {
+    return {
+      enabled: this.enabled,
+      exporterEndpoint: this.config.get<string>('OTEL_EXPORTER_ENDPOINT') ?? 'http://localhost:4318',
+      serviceName: this.config.get<string>('OTEL_SERVICE_NAME') ?? 'stubrix',
+      samplingRate: parseFloat(this.config.get<string>('OTEL_SAMPLING_RATE') ?? '1.0'),
+      jaegerUrl: this.jaegerUrl,
+    };
+  }
+
+  private recordSpan(span: Span): void {
+    if (!this.enabled) return;
+    const traces = this.loadTraces();
+    const existing = traces.find((t) => t.traceId === span.traceId);
+    if (existing) {
+      existing.spans.push(span);
+      existing.duration = Math.max(existing.duration, span.duration);
+    } else {
+      traces.unshift({
+        traceId: span.traceId,
+        spans: [span],
+        duration: span.duration,
+        service: span.service,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    fs.writeFileSync(this.tracesFile, JSON.stringify(traces.slice(0, 500), null, 2));
+  }
+
+  private loadTraces(): Trace[] {
+    if (!fs.existsSync(this.tracesFile)) return [];
+    try { return JSON.parse(fs.readFileSync(this.tracesFile, 'utf-8')) as Trace[]; }
+    catch { return []; }
+  }
+}

--- a/packages/mcp/stubrix-mcp/src/index.js
+++ b/packages/mcp/stubrix-mcp/src/index.js
@@ -1421,6 +1421,138 @@ server.tool(
 );
 
 // ===========================================================================
+// Metrics — Prometheus & Health (F21)
+// ===========================================================================
+
+server.tool(
+  "metrics_health",
+  "Get detailed health status of all Stubrix services with latencies.",
+  {},
+  async () => api("/api/metrics/health"),
+);
+
+server.tool(
+  "metrics_summary",
+  "Get metrics summary — counters, histograms, uptime.",
+  {},
+  async () => api("/api/metrics/summary"),
+);
+
+// ===========================================================================
+// Performance — k6 Testing & Baselines (F22)
+// ===========================================================================
+
+server.tool(
+  "perf_list_scripts",
+  "List k6 performance test scripts (built-in: smoke, load, stress).",
+  {},
+  async () => api("/api/performance/scripts"),
+);
+
+server.tool(
+  "perf_create_script",
+  "Create a custom k6 performance test script.",
+  {
+    name: z.string().describe("Script name"),
+    script: z.string().describe("k6 JavaScript script content"),
+    description: z.string().optional(),
+    options: z.object({
+      vus: z.number().optional(),
+      duration: z.string().optional(),
+    }).optional(),
+  },
+  async ({ name, script, description, options }) =>
+    api("/api/performance/scripts", {
+      method: "POST",
+      body: JSON.stringify({ name, script, description, options: options ?? {} }),
+    }),
+);
+
+server.tool(
+  "perf_list_baselines",
+  "List saved performance baselines.",
+  {},
+  async () => api("/api/performance/baselines"),
+);
+
+server.tool(
+  "perf_save_baseline",
+  "Save a performance baseline from k6 run results.",
+  {
+    name: z.string().describe("Baseline name"),
+    scriptId: z.string().describe("Script ID this baseline belongs to"),
+    p95ResponseMs: z.number().describe("p95 response time in ms"),
+    p99ResponseMs: z.number().describe("p99 response time in ms"),
+    errorRate: z.number().describe("Error rate 0.0-1.0"),
+    requestsPerSec: z.number().describe("Requests per second"),
+  },
+  async ({ name, scriptId, p95ResponseMs, p99ResponseMs, errorRate, requestsPerSec }) =>
+    api("/api/performance/baselines", {
+      method: "POST",
+      body: JSON.stringify({ name, scriptId, metrics: { p95ResponseMs, p99ResponseMs, errorRate, requestsPerSec } }),
+    }),
+);
+
+server.tool(
+  "perf_compare_baseline",
+  "Compare current metrics against a saved baseline — returns pass/fail with regressions (CI gate).",
+  {
+    baselineId: z.string().describe("Baseline UUID"),
+    p95ResponseMs: z.number(),
+    p99ResponseMs: z.number(),
+    errorRate: z.number(),
+    requestsPerSec: z.number(),
+  },
+  async ({ baselineId, p95ResponseMs, p99ResponseMs, errorRate, requestsPerSec }) =>
+    api(`/api/performance/baselines/${baselineId}/compare`, {
+      method: "POST",
+      body: JSON.stringify({ current: { p95ResponseMs, p99ResponseMs, errorRate, requestsPerSec } }),
+    }),
+);
+
+// ===========================================================================
+// Tracing — Jaeger & OpenTelemetry (F28)
+// ===========================================================================
+
+server.tool(
+  "tracing_list",
+  "List recent distributed traces.",
+  {
+    service: z.string().optional().describe("Filter by service name"),
+    limit: z.number().optional().describe("Max traces to return"),
+  },
+  async ({ service, limit }) => {
+    const params = new URLSearchParams();
+    if (service) params.set("service", service);
+    if (limit) params.set("limit", String(limit));
+    return api(`/api/tracing/traces?${params}`);
+  },
+);
+
+server.tool(
+  "tracing_get",
+  "Get a specific distributed trace by ID.",
+  {
+    traceId: z.string().describe("Trace ID"),
+  },
+  async ({ traceId }) => api(`/api/tracing/traces/${traceId}`),
+);
+
+server.tool(
+  "tracing_health",
+  "Check if Jaeger is available.",
+  {},
+  async () => api("/api/tracing/health"),
+);
+
+server.tool(
+  "tracing_config",
+  "Get OpenTelemetry configuration (endpoint, sampling rate, service name).",
+  {},
+  async () => api("/api/tracing/config"),
+);
+
+// ===========================================================================
 // Governance — Spectral Lint (F12)
 // ===========================================================================
 


### PR DESCRIPTION
## Descrição

Milestone **v2.2.0 — Observability & Performance** cobrindo 3 épicos.

## Issues

Closes #146 Closes #147 Closes #148 Closes #149 Closes #150 Closes #151
Closes #152 Closes #153 Closes #154 Closes #155 Closes #156
Closes #186 Closes #187 Closes #188 Closes #189
Closes #43 Closes #44 Closes #50

## O que foi implementado

### F21 — Observability (#146-#151)
- MetricsService — contadores + histogramas Prometheus text format
- GET /api/metrics/prometheus, /summary, /health (latências por serviço)
- Docker profile 'monitoring': Prometheus :9091 + Grafana :3000
- config/prometheus/prometheus.yml pré-configurado

### F22 — Performance Testing (#152-#156)
- 3 scripts k6 built-in: smoke, load, stress
- saveBaseline() + compareBaseline() com gate de 20% regressão
- PerformanceController: scripts CRUD, export JS, baselines CRUD, compare
- 5 MCP tools: perf_list_scripts, perf_create_script, perf_list_baselines, perf_save_baseline, perf_compare_baseline

### F28 — Jaeger / OpenTelemetry (#186-#189)
- Docker profile 'jaeger' (:16686 UI, :4318 OTLP HTTP, :4317 gRPC)
- TracingService: startSpan/finishSpan, OTEL config via env vars
- TracingController: /api/tracing/traces, /health, /config
- 4 MCP tools: tracing_list, tracing_get, tracing_health, tracing_config