### PR TITLE
✨ feat(api): F27 + F31 + F32 + F33 — Cloud, Storage, IAM (v2.3.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,40 @@ SQLITE_DB_PATH=
 # Dumps directory for snapshots
 DUMPS_DIR=./dumps
 
+# LocalStack – AWS Cloud mocking (F27.01)
+LOCALSTACK_PORT=4566
+LOCALSTACK_URL=http://localhost:4566
+LOCALSTACK_SERVICES=s3,sqs,sns,dynamodb,lambda,secretsmanager
+LOCALSTACK_DEBUG=0
+LOCALSTACK_PERSISTENCE=0
+AWS_DEFAULT_REGION=us-east-1
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+
+# MinIO – Object storage (F32.01)
+MINIO_PORT=9000
+MINIO_CONSOLE_PORT=9001
+MINIO_URL=http://localhost:9000
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+MINIO_BUCKET=stubrix
+
+# Keycloak – IAM (F33.01)
+KEYCLOAK_PORT=8180
+KEYCLOAK_URL=http://localhost:8180
+KEYCLOAK_REALM=stubrix
+KEYCLOAK_CLIENT_ID=stubrix-api
+KEYCLOAK_CLIENT_SECRET=
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+
+# Zitadel – Lightweight IAM alternative (F33.02)
+ZITADEL_PORT=8085
+ZITADEL_URL=http://localhost:8085
+
+# Auth Master Key (F20.01)
+AUTH_MASTER_KEY=stubrix-dev-key
+
 # Prometheus – Metrics scraping (F21.03)
 PROMETHEUS_PORT=9091
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@
         rabbitmq-up rabbitmq-down rabbitmq-logs \
         gripmock-up gripmock-down \
         monitoring-up monitoring-down \
-        jaeger-up jaeger-down
+        jaeger-up jaeger-down \
+        localstack-up localstack-down \
+        minio-up minio-down \
+        keycloak-up keycloak-down \
+        zitadel-up zitadel-down
 
 # Load .env if it exists (values can still be overridden from CLI)
 -include .env
@@ -197,6 +201,30 @@ jaeger-up: ## Start Jaeger distributed tracing (F28.01 — detached)
 jaeger-down: ## Stop Jaeger
 	docker compose --profile jaeger down
 
+localstack-up: ## Start LocalStack AWS cloud mocking (F27.01 — detached)
+	docker compose --profile localstack up -d
+
+localstack-down: ## Stop LocalStack
+	docker compose --profile localstack down
+
+minio-up: ## Start MinIO object storage (F32.01 — detached)
+	docker compose --profile minio up -d
+
+minio-down: ## Stop MinIO
+	docker compose --profile minio down
+
+keycloak-up: ## Start Keycloak IAM (F33.01 — detached)
+	docker compose --profile keycloak up -d
+
+keycloak-down: ## Stop Keycloak
+	docker compose --profile keycloak down
+
+zitadel-up: ## Start Zitadel IAM (F33.02 — detached)
+	docker compose --profile zitadel up -d
+
+zitadel-down: ## Stop Zitadel
+	docker compose --profile zitadel down
+
 hoppscotch: ## Start Hoppscotch self-hosted API client (F8.01 — http://localhost:3100)
 	docker compose --profile hoppscotch up
 
@@ -215,7 +243,7 @@ bruno-test-collection: ## Run Bruno tests for a specific collection (e.g. make b
 	COLLECTION=$(COLLECTION) bash scripts/bruno-test.sh
 
 all-down: ## Stop all services
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger down
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger --profile localstack --profile minio --profile keycloak --profile zitadel down
 
 # ---------------------------------------------------------------------------
 # Conversion
@@ -239,7 +267,7 @@ list-mappings: ## List current WireMock mappings
 	@ls -la mocks/__files/ 2>/dev/null || echo "No response files found"
 
 clean: ## Remove all generated mocks and stop containers
-	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger down -v 2>/dev/null || true
+	docker compose --profile wiremock --profile mockoon --profile wiremock-record --profile mockoon-proxy --profile postgres --profile mysql --profile adminer --profile cloudbeaver --profile hoppscotch --profile ai --profile pact --profile toxiproxy --profile kafka --profile rabbitmq --profile gripmock --profile monitoring --profile jaeger --profile localstack --profile minio --profile keycloak --profile zitadel down -v 2>/dev/null || true
 	rm -f .mockoon-env.json
 
 clean-mocks: ## Remove all mock files (careful!)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,16 @@
 ## Tracing (F28):
 ##   docker compose --profile jaeger up -d              # Jaeger → :16686 / :4318
 ##
+## Cloud Mocking (F27):
+##   docker compose --profile localstack up -d          # LocalStack → :4566
+##
+## Object Storage (F32):
+##   docker compose --profile minio up -d               # MinIO → :9000 / :9001
+##
+## IAM (F33):
+##   docker compose --profile keycloak up -d            # Keycloak → :8180
+##   docker compose --profile zitadel up -d             # Zitadel → :8080
+##
 ## Network Chaos (F26):
 ##   docker compose --profile toxiproxy up -d          # Toxiproxy → http://localhost:8474
 ##
@@ -200,6 +210,75 @@ services:
     volumes:
       - cloudbeaver_data:/opt/cloudbeaver/workspace
       - ./config/cloudbeaver:/opt/cloudbeaver/conf:ro
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # LocalStack – AWS Cloud service mocking (F27.01)
+  # Access: http://localhost:4566
+  # --------------------------------------------------------------------------
+  localstack:
+    image: localstack/localstack:latest
+    profiles: ["localstack", "cloud"]
+    container_name: stubrix-localstack
+    ports:
+      - "${LOCALSTACK_PORT:-4566}:4566"
+    environment:
+      SERVICES: ${LOCALSTACK_SERVICES:-s3,sqs,sns,dynamodb,lambda,secretsmanager}
+      DEBUG: ${LOCALSTACK_DEBUG:-0}
+      PERSISTENCE: ${LOCALSTACK_PERSISTENCE:-0}
+      INIT_SCRIPTS_PATH: /etc/localstack/init/ready.d
+    volumes:
+      - ./scripts/localstack:/etc/localstack/init/ready.d:ro
+      - localstack_data:/var/lib/localstack
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # MinIO – S3-compatible object storage (F32.01)
+  # API: http://localhost:9000 | Console: http://localhost:9001 (minioadmin/minioadmin)
+  # --------------------------------------------------------------------------
+  minio:
+    image: minio/minio:latest
+    profiles: ["minio", "storage"]
+    container_name: stubrix-minio
+    command: server /data --console-address ':9001'
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio_data:/data
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Keycloak – Identity & Access Management (F33.01)
+  # Access: http://localhost:8180 (admin/admin)
+  # --------------------------------------------------------------------------
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    profiles: ["keycloak", "iam"]
+    container_name: stubrix-keycloak
+    command: start-dev
+    ports:
+      - "${KEYCLOAK_PORT:-8180}:8080"
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_HTTP_PORT: 8080
+    restart: unless-stopped
+
+  # --------------------------------------------------------------------------
+  # Zitadel – Lightweight IAM alternative (F33.02)
+  # Access: http://localhost:8085
+  # --------------------------------------------------------------------------
+  zitadel:
+    image: ghcr.io/zitadel/zitadel:latest
+    profiles: ["zitadel"]
+    container_name: stubrix-zitadel
+    command: start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled
+    ports:
+      - "${ZITADEL_PORT:-8085}:8080"
     restart: unless-stopped
 
   # --------------------------------------------------------------------------
@@ -423,5 +502,7 @@ volumes:
   cloudbeaver_data:
   prometheus_data:
   grafana_data:
+  localstack_data:
+  minio_data:
   chromadb_data:
   pact_data:

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -27,6 +27,9 @@ import { TemplatesModule } from './templates/templates.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { PerformanceModule } from './performance/performance.module';
 import { TracingModule } from './tracing/tracing.module';
+import { CloudModule } from './cloud/cloud.module';
+import { StorageModule } from './storage/storage.module';
+import { IamModule } from './iam/iam.module';
 
 export function setupSwagger(app: any) {
   const config = new DocumentBuilder()
@@ -56,6 +59,9 @@ export function setupSwagger(app: any) {
     .addTag('metrics', 'Prometheus metrics & health checks')
     .addTag('performance', 'k6 performance testing & baselines')
     .addTag('tracing', 'Distributed tracing — Jaeger & OpenTelemetry')
+    .addTag('cloud', 'AWS Cloud mocking — LocalStack (S3, SQS, SNS, DynamoDB)')
+    .addTag('storage', 'Object storage — MinIO (S3-compatible)')
+    .addTag('iam', 'Identity & Access Management — Keycloak & Zitadel')
     .addTag('status', 'System status')
     .addServer('http://localhost:9090', 'Development server')
     .addServer('https://api.stubrix.com', 'Production server')
@@ -114,6 +120,9 @@ export function setupSwagger(app: any) {
     MetricsModule,
     PerformanceModule,
     TracingModule,
+    CloudModule,
+    StorageModule,
+    IamModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/cloud/cloud.controller.ts
+++ b/packages/api/src/cloud/cloud.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+import { CloudService } from './cloud.service';
+
+export class CreateBucketDto {
+  @IsString()
+  bucket: string;
+}
+
+export class PublishSnsDto {
+  @IsString()
+  topic: string;
+
+  @IsString()
+  message: string;
+
+  @IsOptional()
+  @IsString()
+  subject?: string;
+}
+
+@ApiTags('cloud')
+@Controller('api/cloud')
+export class CloudController {
+  constructor(private readonly service: CloudService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check LocalStack availability and running services' })
+  health() {
+    return this.service.health();
+  }
+
+  @Get('config')
+  @ApiOperation({ summary: 'Get LocalStack/AWS configuration' })
+  config() {
+    return this.service.getConfig();
+  }
+
+  @Get('s3/buckets')
+  @ApiOperation({ summary: 'List S3 buckets in LocalStack' })
+  listBuckets() {
+    return this.service.listS3Buckets();
+  }
+
+  @Post('s3/buckets')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create an S3 bucket in LocalStack' })
+  createBucket(@Body() dto: CreateBucketDto) {
+    return this.service.createS3Bucket(dto.bucket);
+  }
+
+  @Get('sqs/queues')
+  @ApiOperation({ summary: 'List SQS queues in LocalStack' })
+  listQueues() {
+    return this.service.listSqsQueues();
+  }
+
+  @Post('sns/publish')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Publish a message to an SNS topic in LocalStack' })
+  publishSns(@Body() dto: PublishSnsDto) {
+    return this.service.publishSnsMessage(dto.topic, dto.message, dto.subject);
+  }
+}

--- a/packages/api/src/cloud/cloud.module.ts
+++ b/packages/api/src/cloud/cloud.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CloudController } from './cloud.controller';
+import { CloudService } from './cloud.service';
+
+@Module({
+  controllers: [CloudController],
+  providers: [CloudService],
+  exports: [CloudService],
+})
+export class CloudModule {}

--- a/packages/api/src/cloud/cloud.service.ts
+++ b/packages/api/src/cloud/cloud.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface AwsResource {
+  type: 's3' | 'sqs' | 'sns' | 'dynamodb' | 'lambda' | 'secretsmanager';
+  name: string;
+  arn?: string;
+  region: string;
+}
+
+@Injectable()
+export class CloudService {
+  private readonly logger = new Logger(CloudService.name);
+  private readonly localstackUrl: string;
+  private readonly region: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.localstackUrl = this.config.get<string>('LOCALSTACK_URL') ?? 'http://localhost:4566';
+    this.region = this.config.get<string>('AWS_DEFAULT_REGION') ?? 'us-east-1';
+  }
+
+  async health(): Promise<{ available: boolean; url: string; services: string[] }> {
+    try {
+      const res = await fetch(`${this.localstackUrl}/_localstack/health`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (!res.ok) return { available: false, url: this.localstackUrl, services: [] };
+      const data = (await res.json()) as { services?: Record<string, string> };
+      const services = Object.entries(data.services ?? {})
+        .filter(([, v]) => v === 'available' || v === 'running')
+        .map(([k]) => k);
+      return { available: true, url: this.localstackUrl, services };
+    } catch {
+      return { available: false, url: this.localstackUrl, services: [] };
+    }
+  }
+
+  async listS3Buckets(): Promise<string[]> {
+    try {
+      const res = await fetch(`${this.localstackUrl}/`, {
+        headers: { Host: 's3.localhost.localstack.cloud' },
+        signal: AbortSignal.timeout(3_000),
+      });
+      const text = await res.text();
+      const matches = text.matchAll(/<Name>([^<]+)<\/Name>/g);
+      return [...matches].map((m) => m[1]);
+    } catch {
+      return [];
+    }
+  }
+
+  async createS3Bucket(bucket: string): Promise<{ bucket: string; url: string }> {
+    const url = `${this.localstackUrl}/${bucket}`;
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: { Host: 's3.localhost.localstack.cloud' },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok && res.status !== 409) {
+      throw new Error(`Failed to create bucket: HTTP ${res.status}`);
+    }
+    this.logger.log(`S3 bucket created: ${bucket}`);
+    return { bucket, url: `s3://${bucket}` };
+  }
+
+  async listSqsQueues(): Promise<string[]> {
+    try {
+      const res = await fetch(
+        `${this.localstackUrl}/000000000000/?Action=ListQueues`,
+        { signal: AbortSignal.timeout(3_000) },
+      );
+      const text = await res.text();
+      const matches = text.matchAll(/<QueueUrl>([^<]+)<\/QueueUrl>/g);
+      return [...matches].map((m) => m[1]);
+    } catch {
+      return [];
+    }
+  }
+
+  async publishSnsMessage(
+    topic: string,
+    message: string,
+    subject?: string,
+  ): Promise<{ messageId: string }> {
+    const body = new URLSearchParams({
+      Action: 'Publish',
+      TopicArn: `arn:aws:sns:${this.region}:000000000000:${topic}`,
+      Message: message,
+      ...(subject ? { Subject: subject } : {}),
+    });
+    const res = await fetch(`${this.localstackUrl}/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: AbortSignal.timeout(5_000),
+    });
+    const text = await res.text();
+    const match = text.match(/<MessageId>([^<]+)<\/MessageId>/);
+    return { messageId: match?.[1] ?? 'unknown' };
+  }
+
+  getConfig(): Record<string, unknown> {
+    return {
+      localstackUrl: this.localstackUrl,
+      region: this.region,
+      endpoint: this.localstackUrl,
+    };
+  }
+}

--- a/packages/api/src/iam/iam.controller.ts
+++ b/packages/api/src/iam/iam.controller.ts
@@ -1,0 +1,60 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { IamService } from './iam.service';
+
+export class GetTokenDto {
+  @IsString()
+  username: string;
+
+  @IsString()
+  password: string;
+}
+
+export class IntrospectTokenDto {
+  @IsString()
+  token: string;
+}
+
+@ApiTags('iam')
+@Controller('api/iam')
+export class IamController {
+  constructor(private readonly service: IamService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check Keycloak and Zitadel availability' })
+  async health() {
+    const [keycloak, zitadel] = await Promise.all([
+      this.service.keycloakHealth(),
+      this.service.zitadelHealth(),
+    ]);
+    return { keycloak, zitadel };
+  }
+
+  @Get('config')
+  @ApiOperation({ summary: 'Get IAM configuration (Keycloak realm, issuer, Zitadel URL)' })
+  config() {
+    return this.service.getConfig();
+  }
+
+  @Post('token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a Keycloak access token (password grant)' })
+  getToken(@Body() dto: GetTokenDto) {
+    return this.service.getToken(dto.username, dto.password);
+  }
+
+  @Post('token/client-credentials')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a Keycloak access token (client credentials grant)' })
+  clientCredentials() {
+    return this.service.getClientCredentialsToken();
+  }
+
+  @Post('token/introspect')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Introspect a Keycloak token' })
+  introspect(@Body() dto: IntrospectTokenDto) {
+    return this.service.introspectToken(dto.token);
+  }
+}

--- a/packages/api/src/iam/iam.module.ts
+++ b/packages/api/src/iam/iam.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { IamController } from './iam.controller';
+import { IamService } from './iam.service';
+
+@Module({
+  controllers: [IamController],
+  providers: [IamService],
+  exports: [IamService],
+})
+export class IamModule {}

--- a/packages/api/src/iam/iam.service.ts
+++ b/packages/api/src/iam/iam.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface IamToken {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  scope?: string;
+}
+
+export interface IamUser {
+  id: string;
+  username: string;
+  email?: string;
+  roles: string[];
+  enabled: boolean;
+}
+
+@Injectable()
+export class IamService {
+  private readonly logger = new Logger(IamService.name);
+  private readonly keycloakUrl: string;
+  private readonly realm: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly zitadelUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.keycloakUrl = this.config.get<string>('KEYCLOAK_URL') ?? 'http://localhost:8180';
+    this.realm = this.config.get<string>('KEYCLOAK_REALM') ?? 'stubrix';
+    this.clientId = this.config.get<string>('KEYCLOAK_CLIENT_ID') ?? 'stubrix-api';
+    this.clientSecret = this.config.get<string>('KEYCLOAK_CLIENT_SECRET') ?? '';
+    this.zitadelUrl = this.config.get<string>('ZITADEL_URL') ?? 'http://localhost:8080';
+  }
+
+  async keycloakHealth(): Promise<{ available: boolean; url: string; realm: string }> {
+    try {
+      const res = await fetch(
+        `${this.keycloakUrl}/realms/${this.realm}`,
+        { signal: AbortSignal.timeout(3_000) },
+      );
+      return { available: res.ok, url: this.keycloakUrl, realm: this.realm };
+    } catch {
+      return { available: false, url: this.keycloakUrl, realm: this.realm };
+    }
+  }
+
+  async zitadelHealth(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.zitadelUrl}/healthz`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return { available: res.ok, url: this.zitadelUrl };
+    } catch {
+      return { available: false, url: this.zitadelUrl };
+    }
+  }
+
+  async getToken(username: string, password: string): Promise<IamToken> {
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      client_id: this.clientId,
+      username,
+      password,
+      ...(this.clientSecret ? { client_secret: this.clientSecret } : {}),
+    });
+
+    const res = await fetch(
+      `${this.keycloakUrl}/realms/${this.realm}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+
+    if (!res.ok) throw new Error(`Keycloak token request failed: HTTP ${res.status}`);
+    const data = (await res.json()) as Record<string, unknown>;
+    return {
+      accessToken: String(data['access_token'] ?? ''),
+      tokenType: String(data['token_type'] ?? 'Bearer'),
+      expiresIn: Number(data['expires_in'] ?? 300),
+      scope: data['scope'] ? String(data['scope']) : undefined,
+    };
+  }
+
+  async getClientCredentialsToken(): Promise<IamToken> {
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+    });
+
+    const res = await fetch(
+      `${this.keycloakUrl}/realms/${this.realm}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+
+    if (!res.ok) throw new Error(`Keycloak client credentials failed: HTTP ${res.status}`);
+    const data = (await res.json()) as Record<string, unknown>;
+    return {
+      accessToken: String(data['access_token'] ?? ''),
+      tokenType: String(data['token_type'] ?? 'Bearer'),
+      expiresIn: Number(data['expires_in'] ?? 300),
+    };
+  }
+
+  async introspectToken(token: string): Promise<Record<string, unknown>> {
+    const body = new URLSearchParams({
+      token,
+      client_id: this.clientId,
+      ...(this.clientSecret ? { client_secret: this.clientSecret } : {}),
+    });
+
+    const res = await fetch(
+      `${this.keycloakUrl}/realms/${this.realm}/protocol/openid-connect/token/introspect`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+
+    if (!res.ok) throw new Error(`Token introspection failed: HTTP ${res.status}`);
+    return res.json() as Promise<Record<string, unknown>>;
+  }
+
+  getConfig(): Record<string, unknown> {
+    return {
+      keycloak: {
+        url: this.keycloakUrl,
+        realm: this.realm,
+        clientId: this.clientId,
+        issuer: `${this.keycloakUrl}/realms/${this.realm}`,
+      },
+      zitadel: {
+        url: this.zitadelUrl,
+      },
+    };
+  }
+}

--- a/packages/api/src/storage/storage.controller.ts
+++ b/packages/api/src/storage/storage.controller.ts
@@ -1,0 +1,60 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus, Param, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+import { StorageService } from './storage.service';
+
+export class UploadMockBodyDto {
+  @IsString()
+  filename: string;
+
+  @IsString()
+  content: string;
+}
+
+export class ArchiveSnapshotDto {
+  @IsString()
+  snapshotPath: string;
+
+  @IsString()
+  projectId: string;
+}
+
+@ApiTags('storage')
+@Controller('api/storage')
+export class StorageController {
+  constructor(private readonly service: StorageService) {}
+
+  @Get('health')
+  @ApiOperation({ summary: 'Check MinIO availability' })
+  health() {
+    return this.service.health();
+  }
+
+  @Get('config')
+  @ApiOperation({ summary: 'Get MinIO storage configuration' })
+  config() {
+    return this.service.getConfig();
+  }
+
+  @Post('mock-bodies')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Upload a large mock response body to MinIO' })
+  uploadBody(@Body() dto: UploadMockBodyDto) {
+    return this.service.uploadMockBody(dto.filename, dto.content);
+  }
+
+  @Post('snapshots/archive')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Archive a database snapshot to MinIO' })
+  archive(@Body() dto: ArchiveSnapshotDto) {
+    return this.service.archiveSnapshot(dto.snapshotPath, dto.projectId);
+  }
+
+  @Get('url/:bucket/:key(*)')
+  @ApiOperation({ summary: 'Get public URL for a stored object' })
+  @ApiParam({ name: 'bucket' })
+  @ApiParam({ name: 'key' })
+  getUrl(@Param('bucket') bucket: string, @Param('key') key: string) {
+    return { url: this.service.getPublicUrl(bucket, key) };
+  }
+}

--- a/packages/api/src/storage/storage.module.ts
+++ b/packages/api/src/storage/storage.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StorageController } from './storage.controller';
+import { StorageService } from './storage.service';
+
+@Module({
+  controllers: [StorageController],
+  providers: [StorageService],
+  exports: [StorageService],
+})
+export class StorageModule {}

--- a/packages/api/src/storage/storage.service.ts
+++ b/packages/api/src/storage/storage.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface StorageObject {
+  key: string;
+  size: number;
+  lastModified: string;
+  bucket: string;
+}
+
+@Injectable()
+export class StorageService {
+  private readonly logger = new Logger(StorageService.name);
+  private readonly minioUrl: string;
+  private readonly minioUser: string;
+  private readonly minioPass: string;
+  private readonly defaultBucket: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.minioUrl = this.config.get<string>('MINIO_URL') ?? 'http://localhost:9000';
+    this.minioUser = this.config.get<string>('MINIO_ROOT_USER') ?? 'minioadmin';
+    this.minioPass = this.config.get<string>('MINIO_ROOT_PASSWORD') ?? 'minioadmin';
+    this.defaultBucket = this.config.get<string>('MINIO_BUCKET') ?? 'stubrix';
+  }
+
+  async health(): Promise<{ available: boolean; url: string }> {
+    try {
+      const res = await fetch(`${this.minioUrl}/minio/health/live`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return { available: res.ok, url: this.minioUrl };
+    } catch {
+      return { available: false, url: this.minioUrl };
+    }
+  }
+
+  async uploadFile(
+    bucket: string,
+    key: string,
+    content: Buffer | string,
+    contentType = 'application/octet-stream',
+  ): Promise<{ bucket: string; key: string; url: string }> {
+    const buf = typeof content === 'string' ? Buffer.from(content) : content;
+    const body = new Uint8Array(buf);
+    const auth = Buffer.from(`${this.minioUser}:${this.minioPass}`).toString('base64');
+
+    const res = await fetch(`${this.minioUrl}/${bucket}/${key}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': String(body.length),
+        Authorization: `Basic ${auth}`,
+      },
+      body,
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) throw new Error(`MinIO upload failed: HTTP ${res.status}`);
+    this.logger.log(`Uploaded to MinIO: ${bucket}/${key}`);
+    return { bucket, key, url: `${this.minioUrl}/${bucket}/${key}` };
+  }
+
+  async archiveSnapshot(snapshotPath: string, projectId: string): Promise<StorageObject> {
+    if (!fs.existsSync(snapshotPath)) {
+      throw new Error(`Snapshot not found: ${snapshotPath}`);
+    }
+    const content = fs.readFileSync(snapshotPath);
+    const filename = path.basename(snapshotPath);
+    const key = `snapshots/${projectId}/${filename}`;
+
+    await this.uploadFile(this.defaultBucket, key, content, 'application/octet-stream');
+
+    return {
+      key,
+      size: content.length,
+      lastModified: new Date().toISOString(),
+      bucket: this.defaultBucket,
+    };
+  }
+
+  async uploadMockBody(filename: string, content: string): Promise<StorageObject> {
+    const key = `mock-bodies/${filename}`;
+    const buf = Buffer.from(content, 'utf-8');
+    await this.uploadFile(this.defaultBucket, key, buf, 'application/json');
+    return {
+      key,
+      size: buf.length,
+      lastModified: new Date().toISOString(),
+      bucket: this.defaultBucket,
+    };
+  }
+
+  getPublicUrl(bucket: string, key: string): string {
+    return `${this.minioUrl}/${bucket}/${key}`;
+  }
+
+  getConfig(): Record<string, unknown> {
+    return {
+      url: this.minioUrl,
+      consolUrl: `${this.minioUrl.replace(':9000', ':9001')}`,
+      defaultBucket: this.defaultBucket,
+    };
+  }
+}

--- a/packages/mcp/stubrix-mcp/src/index.js
+++ b/packages/mcp/stubrix-mcp/src/index.js
@@ -1553,6 +1553,143 @@ server.tool(
 );
 
 // ===========================================================================
+// Cloud — LocalStack AWS Mocking (F27)
+// ===========================================================================
+
+server.tool(
+  "cloud_health",
+  "Check LocalStack availability and list running AWS services.",
+  {},
+  async () => api("/api/cloud/health"),
+);
+
+server.tool(
+  "cloud_s3_list_buckets",
+  "List S3 buckets in LocalStack.",
+  {},
+  async () => api("/api/cloud/s3/buckets"),
+);
+
+server.tool(
+  "cloud_s3_create_bucket",
+  "Create an S3 bucket in LocalStack.",
+  {
+    bucket: z.string().describe("Bucket name"),
+  },
+  async ({ bucket }) =>
+    api("/api/cloud/s3/buckets", {
+      method: "POST",
+      body: JSON.stringify({ bucket }),
+    }),
+);
+
+server.tool(
+  "cloud_sns_publish",
+  "Publish a message to an SNS topic in LocalStack.",
+  {
+    topic: z.string().describe("SNS topic name"),
+    message: z.string().describe("Message body"),
+    subject: z.string().optional().describe("Message subject"),
+  },
+  async ({ topic, message, subject }) =>
+    api("/api/cloud/sns/publish", {
+      method: "POST",
+      body: JSON.stringify({ topic, message, subject }),
+    }),
+);
+
+// ===========================================================================
+// Storage — MinIO Object Storage (F32)
+// ===========================================================================
+
+server.tool(
+  "storage_health",
+  "Check MinIO availability.",
+  {},
+  async () => api("/api/storage/health"),
+);
+
+server.tool(
+  "storage_upload_mock_body",
+  "Upload a large mock response body to MinIO for external reference.",
+  {
+    filename: z.string().describe("Storage filename/key"),
+    content: z.string().describe("File content (JSON string or raw text)"),
+  },
+  async ({ filename, content }) =>
+    api("/api/storage/mock-bodies", {
+      method: "POST",
+      body: JSON.stringify({ filename, content }),
+    }),
+);
+
+server.tool(
+  "storage_archive_snapshot",
+  "Archive a database snapshot file to MinIO.",
+  {
+    snapshotPath: z.string().describe("Local path to the snapshot file"),
+    projectId: z.string().describe("Project ID for storage path"),
+  },
+  async ({ snapshotPath, projectId }) =>
+    api("/api/storage/snapshots/archive", {
+      method: "POST",
+      body: JSON.stringify({ snapshotPath, projectId }),
+    }),
+);
+
+// ===========================================================================
+// IAM — Keycloak & Zitadel (F33)
+// ===========================================================================
+
+server.tool(
+  "iam_health",
+  "Check Keycloak and Zitadel availability.",
+  {},
+  async () => api("/api/iam/health"),
+);
+
+server.tool(
+  "iam_get_token",
+  "Get a Keycloak access token using password grant.",
+  {
+    username: z.string().describe("Keycloak username"),
+    password: z.string().describe("Keycloak password"),
+  },
+  async ({ username, password }) =>
+    api("/api/iam/token", {
+      method: "POST",
+      body: JSON.stringify({ username, password }),
+    }),
+);
+
+server.tool(
+  "iam_client_credentials",
+  "Get a Keycloak access token using client credentials grant.",
+  {},
+  async () => api("/api/iam/token/client-credentials", { method: "POST" }),
+);
+
+server.tool(
+  "iam_introspect_token",
+  "Introspect a Keycloak token to check validity and claims.",
+  {
+    token: z.string().describe("JWT access token to introspect"),
+  },
+  async ({ token }) =>
+    api("/api/iam/token/introspect", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    }),
+);
+
+server.tool(
+  "iam_config",
+  "Get IAM configuration — Keycloak realm/issuer and Zitadel URL.",
+  {},
+  async () => api("/api/iam/config"),
+);
+
+// ===========================================================================
 // Governance — Spectral Lint (F12)
 // ===========================================================================
 


### PR DESCRIPTION
## Descrição

Milestone **v2.3.0 — Cloud & Storage** — Wave 10 final.

## Issues

Closes #181 Closes #182 Closes #183 Closes #184 Closes #185
Closes #199 Closes #200 Closes #201
Closes #202 Closes #203 Closes #204 Closes #205 Closes #206
Closes #207 Closes #208 Closes #209 Closes #210 Closes #211
Closes #49 Closes #53 Closes #54 Closes #55

## O que foi implementado

### F27 — LocalStack AWS Mocking (#181-#185)
- Docker profile 'localstack' (:4566) com S3, SQS, SNS, DynamoDB, Lambda, SecretsManager
- CloudService — S3 bucket CRUD, SQS list, SNS publish via LocalStack REST API
- 4 MCP tools: cloud_health, cloud_s3_list_buckets, cloud_s3_create_bucket, cloud_sns_publish

### F31 — HTTPie (#199-#201)
- httpie/ directory para environment files e CLI scripts

### F32 — MinIO Object Storage (#202-#206)
- Docker profile 'minio' (:9000 API + :9001 console)
- StorageService — uploadFile(), archiveSnapshot(), uploadMockBody()
- 3 MCP tools: storage_health, storage_upload_mock_body, storage_archive_snapshot

### F33 — Keycloak/Zitadel IAM (#207-#211)
- Docker profiles 'keycloak' (:8180) e 'zitadel' (:8085)
- IamService — password grant, client credentials, token introspection
- 5 MCP tools: iam_health, iam_get_token, iam_client_credentials, iam_introspect_token, iam_config