### PR TITLE
chore(version): bump all packages to v2.3.0 aligned with latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stubrix",
-  "version": "1.3.1",
+  "version": "2.3.0",
   "private": true,
   "workspaces": [
     "packages/shared",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/api",
-  "version": "1.3.1",
+  "version": "2.3.0",
   "description": "Stubrix Control Plane — NestJS backend",
   "author": "Marcelo Davanço",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/cli",
-  "version": "1.3.1",
+  "version": "2.3.0",
   "description": "Stubrix CLI — control plane from the terminal",
   "bin": {
     "stubrix": "./dist/index.js"

--- a/packages/db-ui/package.json
+++ b/packages/db-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stubrix/db-ui",
   "private": true,
-  "version": "1.3.1",
+  "version": "2.3.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/mcp/docker-mcp/package.json
+++ b/packages/mcp/docker-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/docker-mcp",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "private": true,
   "description": "MCP server for Docker Compose operations — manage containers, profiles, logs and health checks",
   "type": "module",

--- a/packages/mcp/stubrix-mcp/package.json
+++ b/packages/mcp/stubrix-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/stubrix-mcp",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "private": true,
   "description": "MCP server for the Stubrix Control Plane API — manage projects, mocks, recordings, databases, and snapshots",
   "type": "module",

--- a/packages/mcp/wiremock-mcp/package.json
+++ b/packages/mcp/wiremock-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/wiremock-mcp",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "private": true,
   "description": "MCP server for WireMock Admin API — manage mappings, recordings, and server state",
   "type": "module",

--- a/packages/mock-ui/package.json
+++ b/packages/mock-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stubrix/mock-ui",
   "private": true,
-  "version": "1.3.1",
+  "version": "2.3.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stubrix/shared",
-  "version": "1.3.1",
+  "version": "2.3.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stubrix/ui",
   "private": true,
-  "version": "1.3.1",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "stubrix-vscode",
   "displayName": "Stubrix",
   "description": "Stubrix mock server integration for VS Code and Windsurf",
-  "version": "1.3.1",
+  "version": "2.3.0",
   "publisher": "stubrix",
   "engines": { "vscode": "^1.85.0" },
   "categories": ["Other", "Testing"],


### PR DESCRIPTION
Sync all package.json versions with the latest GitHub release tag v2.3.0.\n\nBefore: root + 7 packages at v1.3.1, 3 MCP packages at v1.0.0\nAfter: all 11 packages at v2.3.0