### PR TITLE
chore(cli): add npm publish config and GitHub Actions workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,34 @@
+name: Publish @stubrix/cli to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build @stubrix/shared
+        run: npm run build:shared
+
+      - name: Build @stubrix/cli
+        run: npm run build:cli
+
+      - name: Publish @stubrix/cli
+        run: npm publish --workspace packages/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,44 @@
 {
   "name": "@stubrix/cli",
   "version": "2.3.0",
-  "description": "Stubrix CLI — control plane from the terminal",
+  "description": "Stubrix CLI — Advanced API Engineering & Mocking Platform control plane from the terminal",
   "bin": {
     "stubrix": "./dist/index.js"
   },
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "stubrix",
+    "mock",
+    "api-mocking",
+    "wiremock",
+    "mockoon",
+    "cli",
+    "testing",
+    "developer-tools",
+    "rest-api",
+    "contract-testing",
+    "chaos-engineering",
+    "graphql",
+    "grpc"
+  ],
+  "homepage": "https://github.com/marcelo-davanco/stubrix",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marcelo-davanco/stubrix.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/marcelo-davanco/stubrix/issues"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "commander": "^12.1.0",
@@ -22,6 +52,12 @@
     "typescript": "^5.5.0",
     "ts-node": "^10.9.2"
   },
-  "files": ["dist/"],
-  "engines": { "node": ">=18" }
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
 }


### PR DESCRIPTION
Configure @stubrix/cli for publication on the public npm registry.\n\nChanges:\n- packages/cli/package.json: added keywords, repository, homepage, bugs, license, publishConfig (access: public), prepublishOnly script\n- .github/workflows/npm-publish.yml: publish workflow triggered on release:published, builds shared + cli then runs npm publish\n\nSetup required:\n- Add NPM_TOKEN secret to GitHub repo settings (Settings > Secrets > Actions)\n- Get token from npmjs.com > Access Tokens > Generate New Token (Automation)