### PR TITLE
fix(intelligence): align IntelligenceService with real OpenRAG API endpoints

### DIFF
--- a/packages/api/src/intelligence/intelligence.service.ts
+++ b/packages/api/src/intelligence/intelligence.service.ts
@@ -31,6 +31,15 @@ export interface DataSuggestion {
   reasoning?: string;
 }
 
+interface OpenRagChatResponse {
+  response?: string;
+  answer?: string;
+  output?: string;
+  message?: string;
+  sources?: Array<{ id?: string; content?: string; score?: number }>;
+  model?: string;
+}
+
 @Injectable()
 export class IntelligenceService {
   private readonly logger = new Logger(IntelligenceService.name);
@@ -38,86 +47,140 @@ export class IntelligenceService {
   private readonly mappingsDir: string;
 
   constructor(private readonly config: ConfigService) {
-    this.openragUrl = this.config.get<string>('OPENRAG_URL') ?? 'http://localhost:8888';
+    this.openragUrl =
+      this.config.get<string>('OPENRAG_URL') ?? 'http://localhost:8888';
     const mocksDir =
-      this.config.get<string>('MOCKS_DIR') ?? path.join(process.cwd(), '../../mocks');
+      this.config.get<string>('MOCKS_DIR') ??
+      path.join(process.cwd(), '../../mocks');
     this.mappingsDir = path.join(mocksDir, 'mappings');
   }
 
   async query(question: string): Promise<RagQueryResult> {
     try {
-      const res = await fetch(`${this.openragUrl}/query`, {
+      const res = await fetch(`${this.openragUrl}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: question }),
-        signal: AbortSignal.timeout(10_000),
+        body: JSON.stringify({ prompt: question }),
+        signal: AbortSignal.timeout(15_000),
       });
 
       if (!res.ok) {
         throw new Error(`OpenRAG returned HTTP ${res.status}`);
       }
 
-      return (await res.json()) as RagQueryResult;
+      const raw = (await res.json()) as OpenRagChatResponse;
+      return {
+        answer: raw.response ?? raw.answer ?? raw.output ?? raw.message ?? '',
+        sources: (raw.sources ?? []).map((s, i) => ({
+          id: s.id ?? String(i),
+          content: s.content ?? '',
+          score: s.score ?? 0,
+        })),
+        model: raw.model,
+      };
     } catch (err) {
-      this.logger.warn(`OpenRAG unavailable: ${(err as Error).message} — returning stub`);
+      this.logger.warn(
+        `OpenRAG unavailable: ${(err as Error).message} — returning stub`,
+      );
       return this.stubQueryResult(question);
     }
   }
 
   async suggestMock(description: string): Promise<MockSuggestion> {
     const context = this.buildMockContext();
+    const prompt = [
+      'Generate a WireMock JSON mapping for the following description:',
+      description,
+      context ? `\nExisting mocks context:\n${context}` : '',
+      '\nRespond ONLY with valid JSON in the format:',
+      '{"method":"GET","urlPath":"/api/...","responseStatus":200,"responseBody":"{}","responseHeaders":{"Content-Type":"application/json"}}',
+    ].join('\n');
 
     try {
-      const res = await fetch(`${this.openragUrl}/generate/mock`, {
+      const res = await fetch(`${this.openragUrl}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ description, context }),
-        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({ prompt }),
+        signal: AbortSignal.timeout(20_000),
       });
 
       if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
-      return (await res.json()) as MockSuggestion;
+
+      const raw = (await res.json()) as OpenRagChatResponse;
+      const text =
+        raw.response ?? raw.answer ?? raw.output ?? raw.message ?? '';
+      return this.parseMockSuggestion(text, description);
     } catch {
       return this.heuristicMockSuggestion(description);
     }
   }
 
   async suggestData(description: string): Promise<DataSuggestion> {
+    const prompt = [
+      'Generate SQL INSERT statements for the following description:',
+      description,
+      '\nRespond ONLY with valid JSON in the format:',
+      '{"sql":"INSERT INTO ...","tableName":"...","rows":10}',
+    ].join('\n');
+
     try {
-      const res = await fetch(`${this.openragUrl}/generate/data`, {
+      const res = await fetch(`${this.openragUrl}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ description }),
-        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({ prompt }),
+        signal: AbortSignal.timeout(20_000),
       });
 
       if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
-      return (await res.json()) as DataSuggestion;
+
+      const raw = (await res.json()) as OpenRagChatResponse;
+      const text =
+        raw.response ?? raw.answer ?? raw.output ?? raw.message ?? '';
+      return this.parseDataSuggestion(text, description);
     } catch {
       return this.heuristicDataSuggestion(description);
     }
   }
 
   async indexMocks(): Promise<{ indexed: number }> {
-    const docs = this.loadMockDocuments();
-    if (docs.length === 0) return { indexed: 0 };
+    if (!fs.existsSync(this.mappingsDir)) return { indexed: 0 };
 
-    try {
-      const res = await fetch(`${this.openragUrl}/index`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ documents: docs }),
-        signal: AbortSignal.timeout(30_000),
-      });
+    const files = fs
+      .readdirSync(this.mappingsDir)
+      .filter((f) => f.endsWith('.json'));
+    if (files.length === 0) return { indexed: 0 };
 
-      if (!res.ok) throw new Error(`OpenRAG HTTP ${res.status}`);
-      const result = (await res.json()) as { indexed?: number };
-      this.logger.log(`Indexed ${result.indexed ?? docs.length} mock documents into RAG`);
-      return { indexed: result.indexed ?? docs.length };
-    } catch (err) {
-      this.logger.warn(`RAG index unavailable: ${(err as Error).message}`);
-      return { indexed: 0 };
+    let indexed = 0;
+    for (const filename of files) {
+      try {
+        const content = fs.readFileSync(path.join(this.mappingsDir, filename));
+        const form = new FormData();
+        form.append(
+          'file',
+          new Blob([content], { type: 'application/json' }),
+          filename,
+        );
+
+        const res = await fetch(`${this.openragUrl}/upload_context`, {
+          method: 'POST',
+          body: form,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (res.ok) indexed++;
+        else
+          this.logger.warn(`Failed to index ${filename}: HTTP ${res.status}`);
+      } catch (err) {
+        this.logger.warn(
+          `Error indexing ${filename}: ${(err as Error).message}`,
+        );
+      }
     }
+
+    this.logger.log(
+      `Indexed ${indexed}/${files.length} mock files into OpenRAG`,
+    );
+    return { indexed };
   }
 
   async healthCheck(): Promise<{ available: boolean; url: string }> {
@@ -140,11 +203,13 @@ export class IntelligenceService {
         try {
           const raw = fs.readFileSync(path.join(this.mappingsDir, f), 'utf-8');
           const m = JSON.parse(raw) as Record<string, unknown>;
-          return [{
-            id: f.replace('.json', ''),
-            content: JSON.stringify(m),
-            metadata: { filename: f, type: 'wiremock-mapping' },
-          }];
+          return [
+            {
+              id: f.replace('.json', ''),
+              content: JSON.stringify(m),
+              metadata: { filename: f, type: 'wiremock-mapping' },
+            },
+          ];
         } catch {
           return [];
         }
@@ -153,7 +218,56 @@ export class IntelligenceService {
 
   private buildMockContext(): string {
     const docs = this.loadMockDocuments();
-    return docs.slice(0, 5).map((d) => d.content).join('\n\n');
+    return docs
+      .slice(0, 5)
+      .map((d) => d.content)
+      .join('\n\n');
+  }
+
+  private parseMockSuggestion(
+    text: string,
+    description: string,
+  ): MockSuggestion {
+    try {
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]) as Partial<MockSuggestion>;
+        if (parsed.method && parsed.urlPath) {
+          return {
+            method: parsed.method,
+            urlPath: parsed.urlPath,
+            responseStatus: parsed.responseStatus ?? 200,
+            responseBody: parsed.responseBody ?? '{}',
+            responseHeaders: parsed.responseHeaders ?? {
+              'Content-Type': 'application/json',
+            },
+            reasoning: parsed.reasoning ?? text,
+          };
+        }
+      }
+    } catch {}
+    return this.heuristicMockSuggestion(description);
+  }
+
+  private parseDataSuggestion(
+    text: string,
+    description: string,
+  ): DataSuggestion {
+    try {
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]) as Partial<DataSuggestion>;
+        if (parsed.sql && parsed.tableName) {
+          return {
+            sql: parsed.sql,
+            tableName: parsed.tableName,
+            rows: parsed.rows ?? 10,
+            reasoning: parsed.reasoning ?? text,
+          };
+        }
+      }
+    } catch {}
+    return this.heuristicDataSuggestion(description);
   }
 
   private stubQueryResult(question: string): RagQueryResult {
@@ -166,13 +280,14 @@ export class IntelligenceService {
 
   private heuristicMockSuggestion(description: string): MockSuggestion {
     const lower = description.toLowerCase();
-    const method = lower.includes('creat') || lower.includes('post')
-      ? 'POST'
-      : lower.includes('updat') || lower.includes('put')
-      ? 'PUT'
-      : lower.includes('delet')
-      ? 'DELETE'
-      : 'GET';
+    const method =
+      lower.includes('creat') || lower.includes('post')
+        ? 'POST'
+        : lower.includes('updat') || lower.includes('put')
+          ? 'PUT'
+          : lower.includes('delet')
+            ? 'DELETE'
+            : 'GET';
 
     const words = description.match(/\/[a-z0-9_/-]+/i);
     const urlPath = words?.[0] ?? '/api/resource';


### PR DESCRIPTION
## Summary

`IntelligenceService` was calling non-existent OpenRAG endpoints, causing all AI/RAG features to silently fall back to heuristic stubs even when OpenRAG was running and healthy.

## Root Cause

The service was implemented against a hypothetical API (`/query`, `/generate/mock`, `/generate/data`, `/index`) instead of the actual OpenRAG API discovered from `GET /openapi.json`.

## Changes

### `packages/api/src/intelligence/intelligence.service.ts`

| Method | Before (wrong) | After (real OpenRAG API) |
|---|---|---|
| `query()` | `POST /query` | `POST /chat` with `{ prompt }` |
| `suggestMock()` | `POST /generate/mock` | `POST /chat` with WireMock prompt template |
| `suggestData()` | `POST /generate/data` | `POST /chat` with SQL prompt template |
| `indexMocks()` | `POST /index` with JSON body | `POST /upload_context` multipart per file |

**Additional improvements:**
- Add `OpenRagChatResponse` interface for defensive response parsing (handles `response`, `answer`, `output`, `message` fields)
- Add `parseMockSuggestion()` / `parseDataSuggestion()` to extract structured JSON from LLM free text via regex
- Prompt engineering for `suggestMock` includes existing mocks as context (up to 5)
- Graceful degradation preserved: heuristic fallbacks apply when `OPENAI_API_KEY` is not configured or OpenRAG is offline

## Requirements

OpenRAG full functionality requires either:
- `OPENAI_API_KEY` — OpenAI embeddings (`text-embedding-3-small`) + LLM
- `OLLAMA_ENDPOINT` — local Ollama with embedding model configured

## Testing

- `GET /api/intelligence/health` — confirms OpenRAG reachability
- `POST /api/intelligence/query` — routes to `POST /chat` on OpenRAG
- `POST /api/intelligence/suggest/mock` — routes to `POST /chat` with WireMock prompt
- `POST /api/intelligence/index` — uploads each mock file via `POST /upload_context`