### PR TITLE
🔧 chore(git): require 1 review approval on all branches (dev/stg/main)

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -83,7 +83,7 @@ Stubrix is a monorepo (npm workspaces) that provides a unified mock server platf
 - **main**: Production only — receives merges exclusively from `stg` via PR with 1 review required
 - Flow: `feat/*` or `fix/*` → `dev` → `stg` → `main`
 - **All three branches require PR** — never push directly to `main`, `stg`, or `dev`
-- `dev` PR: no review required; `stg` PR: 1 review required; `main` PR: 1 review + CodeQL
+- All PRs require 1 review approval and CodeQL passing
 
 ## Feature Development
 


### PR DESCRIPTION
## What
Enforce code review with approval on all three protected branches.

## Why
Ensure no code reaches any protected branch without peer review, including `dev`.

## Changes
- Update `.windsurfrules`: all PRs require 1 review approval
- `dev` ruleset: `required_approving_review_count` 0 → 1
- `dev` classic protection: 1 required review added

## Impact
Consistent review gate across `dev` → `stg` → `main` pipeline.